### PR TITLE
YouTube再生の初期化待ちを安定化

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,7 @@
 </div>
 
   <script src="./script.js"></script>
+  <script src="./youtube-stability.js"></script>
 
 </body>
 </html>

--- a/youtube-stability.js
+++ b/youtube-stability.js
@@ -30,6 +30,16 @@
     const tryPlay = () => {
       if (!pendingYouTubeVideo) return;
 
+      if (
+        (typeof ytPlayer === "undefined" || !ytPlayer) &&
+        typeof YT !== "undefined" &&
+        typeof YT.Player === "function" &&
+        typeof tryInitYtPlayer === "function"
+      ) {
+        ytApiReady = true;
+        tryInitYtPlayer();
+      }
+
       if (typeof ytPlayer !== "undefined" && ytPlayer && typeof ytPlayer.loadVideoById === "function") {
         const { videoId, start } = pendingYouTubeVideo;
         pendingYouTubeVideo = null;

--- a/youtube-stability.js
+++ b/youtube-stability.js
@@ -1,0 +1,72 @@
+(function () {
+  let pendingYouTubeVideo = null;
+  let retryTimer = null;
+
+  function getYouTubeVideoData(video) {
+    let videoId = video?.["videoId"];
+    const platform = String(video?.["platform"] || "").toLowerCase();
+
+    if (!videoId || !platform.includes("youtube")) return null;
+
+    const match = String(videoId).match(/(?:v=|\/|youtu\.be\/)?([0-9A-Za-z_-]{11})/);
+    if (match) videoId = match[1];
+
+    return {
+      videoId,
+      start: parseInt(video?.["start"] || "0", 10)
+    };
+  }
+
+  function playWhenReady() {
+    if (!pendingYouTubeVideo) return;
+
+    if (retryTimer) {
+      clearTimeout(retryTimer);
+      retryTimer = null;
+    }
+
+    let attempts = 0;
+
+    const tryPlay = () => {
+      if (!pendingYouTubeVideo) return;
+
+      if (typeof ytPlayer !== "undefined" && ytPlayer && typeof ytPlayer.loadVideoById === "function") {
+        const { videoId, start } = pendingYouTubeVideo;
+        pendingYouTubeVideo = null;
+        ytPlayer.loadVideoById({ videoId, startSeconds: start });
+        return;
+      }
+
+      attempts += 1;
+      if (attempts <= 40) {
+        retryTimer = setTimeout(tryPlay, 100);
+      }
+    };
+
+    tryPlay();
+  }
+
+  const originalLoadVideo = loadVideo;
+
+  loadVideo = function (video, item) {
+    const youtubeVideo = getYouTubeVideoData(video);
+    if (youtubeVideo) {
+      pendingYouTubeVideo = youtubeVideo;
+    } else {
+      pendingYouTubeVideo = null;
+    }
+
+    originalLoadVideo(video, item);
+    playWhenReady();
+  };
+
+  const originalOnYouTubeIframeAPIReady = window.onYouTubeIframeAPIReady;
+
+  window.onYouTubeIframeAPIReady = function () {
+    if (typeof originalOnYouTubeIframeAPIReady === "function") {
+      originalOnYouTubeIframeAPIReady();
+    }
+
+    playWhenReady();
+  };
+})();


### PR DESCRIPTION
## 変更内容
- YouTube動画クリック時に、プレイヤー準備が終わるまで再生対象を一時保存する処理を追加
- YouTube IFrame API が先に読み込まれていた場合でも、プレイヤー初期化を再実行できるように補助
- `index.html` で補助スクリプト `youtube-stability.js` を読み込むように変更

## 確認したいこと
- ページ読み込み直後にYouTube動画を押しても再生される
- 連続で別のYouTube動画を押しても、最後に押した動画が再生される
- TikTok動画へ切り替えてもYouTube側の保留再生が割り込まない
- 既存の前へ / 次へ / ランダム再生が動く