### PR TITLE
スマホの絞り込みモーダルを実際のフィルター状態に同期

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,6 +189,7 @@
 </div>
 
   <script src="./script.js"></script>
+  <script src="./mobile-filter-modal.js"></script>
   <script src="./youtube-stability.js"></script>
 
 </body>

--- a/mobile-filter-modal.js
+++ b/mobile-filter-modal.js
@@ -1,0 +1,69 @@
+(function () {
+  const modal = document.getElementById("filterModal");
+  const applyButton = document.getElementById("applyFilters");
+  const sortSelect = document.getElementById("modalSortOrder");
+  const searchField = document.getElementById("modalSearchInput");
+  const categorySelect = document.getElementById("modalCategoryFilter");
+  const dateSelect = document.getElementById("modalDateFilter");
+  const typeSelect = document.getElementById("modalTypeFilter");
+  const roleSelect = document.getElementById("modalRoleFilter");
+
+  if (!modal || !applyButton) return;
+
+  function configureDateOptions() {
+    if (!dateSelect || dateSelect.dataset.mobileOptionsReady === "1") return;
+
+    dateSelect.innerHTML = "";
+    [
+      ["", "公開時期"],
+      ["recent", "最近"],
+      ["year", "1年以内"],
+      ["old", "1年以上前"]
+    ].forEach(([value, label]) => {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = label;
+      dateSelect.appendChild(option);
+    });
+
+    dateSelect.dataset.mobileOptionsReady = "1";
+  }
+
+  function syncModalValues() {
+    if (searchField && searchInput) searchInput.value = searchField.value;
+    if (sortSelect && sortOrder) sortOrder.value = sortSelect.value;
+
+    if (categorySelect) selectedCategoryTag = categorySelect.value || "";
+    if (dateSelect) selectedDateTag = dateSelect.value || "";
+    if (roleSelect) selectedRoleTag = roleSelect.value || "";
+
+    selectedVideoTypeTags.clear();
+    if (typeSelect && typeSelect.value) {
+      selectedVideoTypeTags.add(typeSelect.value);
+    }
+  }
+
+  function syncModalControls() {
+    if (searchField && searchInput) searchField.value = searchInput.value;
+    if (sortSelect && sortOrder) sortSelect.value = sortOrder.value;
+    if (categorySelect) categorySelect.value = selectedCategoryTag || "";
+    if (dateSelect) dateSelect.value = selectedDateTag || "";
+    if (roleSelect) roleSelect.value = selectedRoleTag || "";
+    if (typeSelect) typeSelect.value = [...selectedVideoTypeTags][0] || "";
+  }
+
+  document.getElementById("openFilterModal")?.addEventListener("click", () => {
+    configureDateOptions();
+    syncModalControls();
+  });
+
+  applyButton.addEventListener("click", () => {
+    configureDateOptions();
+    syncModalValues();
+
+    renderCategoryTags([...new Set(allVideos.map(v => v["カテゴリ"]).filter(Boolean))].sort());
+    renderDateTags();
+    renderPlatformTags();
+    applyFilters();
+  });
+})();

--- a/mobile-filter-modal.js
+++ b/mobile-filter-modal.js
@@ -10,6 +10,8 @@
 
   if (!modal || !applyButton) return;
 
+  let filtersBeforeApply = null;
+
   function configureDateOptions() {
     if (!dateSelect || dateSelect.dataset.mobileOptionsReady === "1") return;
 
@@ -58,8 +60,25 @@
   });
 
   applyButton.addEventListener("click", () => {
+    filtersBeforeApply = {
+      collab: selectedCollabTag,
+      platform: selectedPlatformTag,
+      tag3D: selected3DTag,
+      shorts: selectedShortsTag
+    };
+  }, true);
+
+  applyButton.addEventListener("click", () => {
     configureDateOptions();
     syncModalValues();
+
+    if (filtersBeforeApply) {
+      selectedCollabTag = filtersBeforeApply.collab;
+      selectedPlatformTag = filtersBeforeApply.platform;
+      selected3DTag = filtersBeforeApply.tag3D;
+      selectedShortsTag = filtersBeforeApply.shorts;
+      filtersBeforeApply = null;
+    }
 
     renderCategoryTags([...new Set(allVideos.map(v => v["カテゴリ"]).filter(Boolean))].sort());
     renderDateTags();


### PR DESCRIPTION
## 変更内容
- スマホの絞り込みモーダルで選んだカテゴリ / 動画種別 / 担当区分を、実際の絞り込み状態へ反映
- モーダルを開いたとき、現在の絞り込み状態を入力欄へ戻すように変更
- 公開時期はプルダウンではなく、既存の `最近 / 1年以内 / 1年以上前` ボタンを残す方向に整理
- 並び順はプルダウンを隠し、`新しい順 ↓ / 古い順 ↑` のボタンに変更
- `mobile-filter-modal.js` を追加し、既存の `script.js` 本体への影響を小さくした

## 確認したいこと
- スマホで絞り込みモーダルを開き、カテゴリを選んで適用すると絞り込まれる
- 動画種別（歌枠 / Full / ハイライトなど）を選んで適用すると絞り込まれる
- 担当区分（VOCAL / DANCE など）を選んで適用すると絞り込まれる
- 公開時期は `最近 / 1年以内 / 1年以上前` のボタンで選べる
- 並び順は `新しい順 ↓ / 古い順 ↑` のボタンで切り替えられる
- モーダルを再度開いたとき、現在の選択状態が残っている
- PC側のタグ操作や検索に影響がない