### PR TITLE
スマホ絞り込みモーダルをタグ操作に寄せる

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,9 +188,9 @@
   </div>
 </div>
 
-  <script src="./script.js"></script>
-  <script src="./mobile-filter-modal.js"></script>
-  <script src="./youtube-stability.js"></script>
+  <script src="./script.js?v=13"></script>
+  <script src="./mobile-filter-modal.js?v=13"></script>
+  <script src="./youtube-stability.js?v=13"></script>
 
 </body>
 </html>

--- a/mobile-filter-modal.js
+++ b/mobile-filter-modal.js
@@ -30,11 +30,13 @@
     sortSelect.classList.add("hidden");
 
     sortButtonGroup = document.createElement("div");
-    sortButtonGroup.className = "flex gap-2";
+    sortButtonGroup.className = "flex flex-wrap gap-2";
 
     [
       ["desc", "新しい順 ↓"],
-      ["asc", "古い順 ↑"]
+      ["asc", "古い順 ↑"],
+      ["title", "タイトル順"],
+      ["artist", "アーティスト順"]
     ].forEach(([value, label]) => {
       const button = document.createElement("button");
       button.type = "button";
@@ -52,19 +54,65 @@
     updateSortButtons();
   }
 
+  function configureCategoryButtons() {
+    if (categorySelect) categorySelect.classList.add("hidden");
+  }
+
   function configureDateButtons() {
     if (dateSelect) dateSelect.classList.add("hidden");
+  }
+
+  function resetModalFilters() {
+    if (searchField) searchField.value = "";
+    if (searchInput) searchInput.value = "";
+    if (sortSelect) sortSelect.value = "desc";
+    if (sortOrder) sortOrder.value = "desc";
+    if (categorySelect) categorySelect.value = "";
+    if (dateSelect) dateSelect.value = "";
+    if (typeSelect) typeSelect.value = "";
+    if (roleSelect) roleSelect.value = "";
+
+    selectedCategoryTag = "";
+    selectedCollabTag = "";
+    selectedRoleTag = "";
+    selectedPlatformTag = "";
+    selectedDateTag = "";
+    selected3DTag = null;
+    selectedShortsTag = null;
+    selectedVideoTypeTags.clear();
+
+    renderCategoryTags([...new Set(allVideos.map(v => v["カテゴリ"]).filter(Boolean))].sort());
+    renderDateTags();
+    renderPlatformTags();
+    updateSortButtons();
+    applyFilters();
+  }
+
+  function configureResetButton() {
+    if (document.getElementById("resetModalFilters")) return;
+
+    const actions = applyButton.parentElement;
+    if (!actions) return;
+
+    const resetButton = document.createElement("button");
+    resetButton.id = "resetModalFilters";
+    resetButton.type = "button";
+    resetButton.className = "bg-gray-100 text-gray-700 px-4 py-2 rounded-md";
+    resetButton.textContent = "リセット";
+    resetButton.addEventListener("click", resetModalFilters);
+
+    applyButton.insertAdjacentElement("afterend", resetButton);
+    actions.classList.remove("justify-between");
+    actions.classList.add("justify-start", "gap-3", "items-center");
   }
 
   function syncModalValues() {
     if (searchField && searchInput) searchInput.value = searchField.value;
     if (sortSelect && sortOrder) sortOrder.value = sortSelect.value || "desc";
 
-    if (categorySelect) selectedCategoryTag = categorySelect.value || "";
-    if (roleSelect) selectedRoleTag = roleSelect.value || "";
-
-    selectedVideoTypeTags.clear();
+    if (roleSelect && roleSelect.value) selectedRoleTag = roleSelect.value;
     if (typeSelect && typeSelect.value) {
+      selectedVideoTypeTags.clear();
       selectedVideoTypeTags.add(typeSelect.value);
     }
   }
@@ -80,31 +128,44 @@
 
   document.getElementById("openFilterModal")?.addEventListener("click", () => {
     configureSortButtons();
+    configureCategoryButtons();
     configureDateButtons();
+    configureResetButton();
     syncModalControls();
   });
 
   applyButton.addEventListener("click", () => {
     filtersBeforeApply = {
+      category: selectedCategoryTag,
       date: selectedDateTag,
       collab: selectedCollabTag,
+      role: selectedRoleTag,
       platform: selectedPlatformTag,
       tag3D: selected3DTag,
-      shorts: selectedShortsTag
+      shorts: selectedShortsTag,
+      videoTypes: new Set(selectedVideoTypeTags)
     };
   }, true);
 
   applyButton.addEventListener("click", () => {
     configureSortButtons();
+    configureCategoryButtons();
     configureDateButtons();
+    configureResetButton();
     syncModalValues();
 
     if (filtersBeforeApply) {
+      selectedCategoryTag = filtersBeforeApply.category;
       selectedDateTag = filtersBeforeApply.date;
       selectedCollabTag = filtersBeforeApply.collab;
+      if (!roleSelect || !roleSelect.value) selectedRoleTag = filtersBeforeApply.role;
       selectedPlatformTag = filtersBeforeApply.platform;
       selected3DTag = filtersBeforeApply.tag3D;
       selectedShortsTag = filtersBeforeApply.shorts;
+      if (!typeSelect || !typeSelect.value) {
+        selectedVideoTypeTags.clear();
+        filtersBeforeApply.videoTypes.forEach(tag => selectedVideoTypeTags.add(tag));
+      }
       filtersBeforeApply = null;
     }
 


### PR DESCRIPTION
## 変更内容
- スマホ絞り込みモーダルのカテゴリプルダウンを非表示にし、カテゴリタグで操作する形に寄せました
- タグを選んだあとに「適用」を押しても、選択済みタグが消えないようにしました
- モーダル下部の「適用」の隣に「リセット」ボタンを追加しました
- 並び順ボタンに「タイトル順」「アーティスト順」を追加しました
- JSの読み込みに `?v=13` を付け、反映確認時に古いキャッシュを掴みにくくしました

## 確認してほしいこと
- スマホ表示で「絞り込み」を開いたとき、カテゴリのプルダウンが見えないこと
- カテゴリや公開時期などのタグを選んで「適用」を押しても、絞り込みがリセットされないこと
- 「リセット」で絞り込みが全部解除されること
- 「新しい順 / 古い順 / タイトル順 / アーティスト順」が切り替わること