### PR TITLE
スマホ絞り込みに英語見出しとタグ項目を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,34 +93,58 @@
 
 <!-- モーダル本体 -->
 <div id="filterModal" class="fixed inset-0 bg-black bg-opacity-50 z-40 flex items-center justify-center hidden">
-  <div class="bg-white w-11/12 max-w-md p-4 rounded-lg shadow-lg">
+  <div class="bg-white w-11/12 max-w-md max-h-[90vh] overflow-y-auto p-4 rounded-lg shadow-lg">
     <h2 class="text-lg font-bold mb-4">絞り込み</h2>
     
     <!-- モーダル用のフィルター入力欄 -->
     <div class="space-y-3">
+      <div>
+        <p class="text-xs font-semibold text-gray-500 mb-2">Sort</p>
         <select id="modalSortOrder" class="w-full border p-2 rounded">
     <option value="desc">新しい順</option>
     <option value="asc">古い順</option>
     <option value="title">曲名順</option>
     <option value="artist">アーティスト順</option>
   </select>
+      </div>
+
+      <div>
+        <p class="text-xs font-semibold text-gray-500 mb-2">Style</p>
       <select id="modalCategoryFilter" class="w-full border p-2 rounded">
         <option value="">カテゴリ</option>
       </select>
-
       <div id="modalCategoryTags" class="flex flex-wrap gap-2 mt-2"></div>
+      </div>
+
+      <div>
+        <p class="text-xs font-semibold text-gray-500 mb-2">Platform</p>
       <div id="modalPlatformTags" class="flex flex-wrap gap-2 mt-2"></div>
+      </div>
+
+      <div>
+        <p class="text-xs font-semibold text-gray-500 mb-2">Time</p>
       <div id="modalDateTags" class="flex flex-wrap gap-2 mt-2"></div>
-      
       <select id="modalDateFilter" class="w-full border p-2 rounded">
         <option value="">公開日</option>
       </select>
+      </div>
+
+      <div>
+        <p class="text-xs font-semibold text-gray-500 mb-2">Format</p>
       <select id="modalTypeFilter" class="w-full border p-2 rounded">
         <option value="">動画種別</option>
       </select>
+      <div id="modalFormatTags" class="flex flex-wrap gap-2 mt-2"></div>
+      </div>
+
+      <div>
+        <p class="text-xs font-semibold text-gray-500 mb-2">Riko Part</p>
       <select id="modalRoleFilter" class="w-full border p-2 rounded">
         <option value="">担当区分</option>
       </select>
+      <div id="modalRoleTags" class="flex flex-wrap gap-2 mt-2"></div>
+      </div>
+
       <input id="modalSearchInput" type="text" placeholder="曲名・アーティスト・タグ" class="w-full border p-2 rounded" />
     </div>
 
@@ -188,9 +212,9 @@
   </div>
 </div>
 
-  <script src="./script.js?v=13"></script>
-  <script src="./mobile-filter-modal.js?v=13"></script>
-  <script src="./youtube-stability.js?v=13"></script>
+  <script src="./script.js?v=14"></script>
+  <script src="./mobile-filter-modal.js?v=14"></script>
+  <script src="./youtube-stability.js?v=14"></script>
 
 </body>
 </html>

--- a/mobile-filter-modal.js
+++ b/mobile-filter-modal.js
@@ -7,6 +7,8 @@
   const dateSelect = document.getElementById("modalDateFilter");
   const typeSelect = document.getElementById("modalTypeFilter");
   const roleSelect = document.getElementById("modalRoleFilter");
+  const formatTagsContainer = document.getElementById("modalFormatTags");
+  const roleTagsContainer = document.getElementById("modalRoleTags");
 
   if (!modal || !applyButton) return;
 
@@ -62,6 +64,105 @@
     if (dateSelect) dateSelect.classList.add("hidden");
   }
 
+  function configureFormatButtons() {
+    if (typeSelect) typeSelect.classList.add("hidden");
+  }
+
+  function configureRoleButtons() {
+    if (roleSelect) roleSelect.classList.add("hidden");
+  }
+
+  function getSelectValues(select) {
+    if (!select) return [];
+
+    return [...select.options]
+      .map(option => option.value)
+      .filter(Boolean);
+  }
+
+  function getFormatValues() {
+    const values = getSelectValues(typeSelect);
+
+    if (allVideos.some(video => video["3D"] === "TRUE")) values.push("3D");
+    if (allVideos.some(video => video["Shorts"] === "TRUE")) values.push("Shorts");
+
+    return [...new Set(values)];
+  }
+
+  function getFormatButtonClass(isActive) {
+    return isActive
+      ? "bg-pink-600 text-white px-3 py-1 rounded-full text-xs"
+      : "bg-pink-100 text-pink-700 px-3 py-1 rounded-full text-xs";
+  }
+
+  function renderFormatTags() {
+    if (!formatTagsContainer) return;
+
+    formatTagsContainer.innerHTML = "";
+
+    getFormatValues().forEach(format => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = format;
+
+      const is3D = format === "3D";
+      const isShorts = format === "Shorts";
+      const isActive = is3D
+        ? selected3DTag === "include"
+        : isShorts
+          ? selectedShortsTag === "include"
+          : selectedVideoTypeTags.has(format);
+
+      button.className = getFormatButtonClass(isActive);
+      button.addEventListener("click", () => {
+        if (is3D) {
+          selected3DTag = selected3DTag === "include" ? null : "include";
+        } else if (isShorts) {
+          selectedShortsTag = selectedShortsTag === "include" ? null : "include";
+        } else {
+          toggleVideoTypeTag(format);
+        }
+
+        if (typeSelect) typeSelect.value = "";
+        renderFormatTags();
+        applyFilters();
+      });
+
+      formatTagsContainer.appendChild(button);
+    });
+  }
+
+  function renderRoleTags() {
+    if (!roleTagsContainer) return;
+
+    roleTagsContainer.innerHTML = "";
+
+    getSelectValues(roleSelect).forEach(role => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = role;
+
+      const isActive = selectedRoleTag === role;
+      button.className = isActive
+        ? "bg-amber-600 text-white px-3 py-1 rounded-full text-xs"
+        : "bg-amber-100 text-amber-700 px-3 py-1 rounded-full text-xs";
+      button.addEventListener("click", () => {
+        selectedRoleTag = selectedRoleTag === role ? "" : role;
+
+        if (roleSelect) roleSelect.value = "";
+        renderRoleTags();
+        applyFilters();
+      });
+
+      roleTagsContainer.appendChild(button);
+    });
+  }
+
+  function renderMobileTagSections() {
+    renderFormatTags();
+    renderRoleTags();
+  }
+
   function resetModalFilters() {
     if (searchField) searchField.value = "";
     if (searchInput) searchInput.value = "";
@@ -84,6 +185,7 @@
     renderCategoryTags([...new Set(allVideos.map(v => v["カテゴリ"]).filter(Boolean))].sort());
     renderDateTags();
     renderPlatformTags();
+    renderMobileTagSections();
     updateSortButtons();
     applyFilters();
   }
@@ -109,27 +211,24 @@
   function syncModalValues() {
     if (searchField && searchInput) searchInput.value = searchField.value;
     if (sortSelect && sortOrder) sortOrder.value = sortSelect.value || "desc";
-
-    if (roleSelect && roleSelect.value) selectedRoleTag = roleSelect.value;
-    if (typeSelect && typeSelect.value) {
-      selectedVideoTypeTags.clear();
-      selectedVideoTypeTags.add(typeSelect.value);
-    }
   }
 
   function syncModalControls() {
     if (searchField && searchInput) searchField.value = searchInput.value;
     if (sortSelect && sortOrder) sortSelect.value = sortOrder.value || "desc";
     if (categorySelect) categorySelect.value = selectedCategoryTag || "";
-    if (roleSelect) roleSelect.value = selectedRoleTag || "";
-    if (typeSelect) typeSelect.value = [...selectedVideoTypeTags][0] || "";
+    if (roleSelect) roleSelect.value = "";
+    if (typeSelect) typeSelect.value = "";
     updateSortButtons();
+    renderMobileTagSections();
   }
 
   document.getElementById("openFilterModal")?.addEventListener("click", () => {
     configureSortButtons();
     configureCategoryButtons();
     configureDateButtons();
+    configureFormatButtons();
+    configureRoleButtons();
     configureResetButton();
     syncModalControls();
   });
@@ -151,6 +250,8 @@
     configureSortButtons();
     configureCategoryButtons();
     configureDateButtons();
+    configureFormatButtons();
+    configureRoleButtons();
     configureResetButton();
     syncModalValues();
 
@@ -158,20 +259,19 @@
       selectedCategoryTag = filtersBeforeApply.category;
       selectedDateTag = filtersBeforeApply.date;
       selectedCollabTag = filtersBeforeApply.collab;
-      if (!roleSelect || !roleSelect.value) selectedRoleTag = filtersBeforeApply.role;
+      selectedRoleTag = filtersBeforeApply.role;
       selectedPlatformTag = filtersBeforeApply.platform;
       selected3DTag = filtersBeforeApply.tag3D;
       selectedShortsTag = filtersBeforeApply.shorts;
-      if (!typeSelect || !typeSelect.value) {
-        selectedVideoTypeTags.clear();
-        filtersBeforeApply.videoTypes.forEach(tag => selectedVideoTypeTags.add(tag));
-      }
+      selectedVideoTypeTags.clear();
+      filtersBeforeApply.videoTypes.forEach(tag => selectedVideoTypeTags.add(tag));
       filtersBeforeApply = null;
     }
 
     renderCategoryTags([...new Set(allVideos.map(v => v["カテゴリ"]).filter(Boolean))].sort());
     renderDateTags();
     renderPlatformTags();
+    renderMobileTagSections();
     applyFilters();
   });
 })();


### PR DESCRIPTION
## 変更内容
- スマホ絞り込みモーダルに短い英語見出しを追加しました
  - Sort
  - Style
  - Platform
  - Time
  - Format
  - Riko Part
- `動画種別` と `担当区分` のプルダウンを非表示にし、タグで選べるようにしました
- `Format` には動画種別に加えて `3D` / `Shorts` も表示されるようにしました
- タグ項目が増えても画面からはみ出しにくいよう、モーダル内をスクロール可能にしました
- JSの読み込み番号を `?v=14` に更新しました

## 確認してほしいこと
- スマホの絞り込みで `Style / Platform / Time / Format / Riko Part` が見やすく分かれていること
- `Format` のタグを押すと絞り込みが反映されること
- `Riko Part` のタグを押すと絞り込みが反映されること
- リセットで追加したタグ条件も解除されること