### PR TITLE
スマホ絞り込みにCollabタグを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
     <!-- モーダル用のフィルター入力欄 -->
     <div class="space-y-3">
       <div>
-        <p class="text-xs font-semibold text-gray-500 mb-2">Sort</p>
+        <p class="modal-section-title">Sort</p>
         <select id="modalSortOrder" class="w-full border p-2 rounded">
     <option value="desc">新しい順</option>
     <option value="asc">古い順</option>
@@ -109,7 +109,7 @@
       </div>
 
       <div>
-        <p class="text-xs font-semibold text-gray-500 mb-2">Style</p>
+        <p class="modal-section-title">Style</p>
       <select id="modalCategoryFilter" class="w-full border p-2 rounded">
         <option value="">カテゴリ</option>
       </select>
@@ -117,12 +117,12 @@
       </div>
 
       <div>
-        <p class="text-xs font-semibold text-gray-500 mb-2">Platform</p>
+        <p class="modal-section-title">Platform</p>
       <div id="modalPlatformTags" class="flex flex-wrap gap-2 mt-2"></div>
       </div>
 
       <div>
-        <p class="text-xs font-semibold text-gray-500 mb-2">Time</p>
+        <p class="modal-section-title">Time</p>
       <div id="modalDateTags" class="flex flex-wrap gap-2 mt-2"></div>
       <select id="modalDateFilter" class="w-full border p-2 rounded">
         <option value="">公開日</option>
@@ -130,7 +130,7 @@
       </div>
 
       <div>
-        <p class="text-xs font-semibold text-gray-500 mb-2">Format</p>
+        <p class="modal-section-title">Format</p>
       <select id="modalTypeFilter" class="w-full border p-2 rounded">
         <option value="">動画種別</option>
       </select>
@@ -138,11 +138,25 @@
       </div>
 
       <div>
-        <p class="text-xs font-semibold text-gray-500 mb-2">Riko Part</p>
+        <p class="modal-section-title">Riko Part</p>
       <select id="modalRoleFilter" class="w-full border p-2 rounded">
         <option value="">担当区分</option>
       </select>
       <div id="modalRoleTags" class="flex flex-wrap gap-2 mt-2"></div>
+      </div>
+
+      <div>
+        <p class="modal-section-title">Collab</p>
+        <div class="modal-collab-scroll">
+          <div>
+            <p class="modal-subsection-title">Liver</p>
+            <div id="modalCollabLiverTags" class="flex flex-wrap gap-2 mt-2"></div>
+          </div>
+          <div>
+            <p class="modal-subsection-title">Unit</p>
+            <div id="modalCollabUnitTags" class="flex flex-wrap gap-2 mt-2"></div>
+          </div>
+        </div>
       </div>
 
       <input id="modalSearchInput" type="text" placeholder="曲名・アーティスト・タグ" class="w-full border p-2 rounded" />
@@ -212,9 +226,9 @@
   </div>
 </div>
 
-  <script src="./script.js?v=14"></script>
-  <script src="./mobile-filter-modal.js?v=14"></script>
-  <script src="./youtube-stability.js?v=14"></script>
+  <script src="./script.js?v=15"></script>
+  <script src="./mobile-filter-modal.js?v=15"></script>
+  <script src="./youtube-stability.js?v=15"></script>
 
 </body>
 </html>

--- a/mobile-filter-modal.js
+++ b/mobile-filter-modal.js
@@ -9,6 +9,8 @@
   const roleSelect = document.getElementById("modalRoleFilter");
   const formatTagsContainer = document.getElementById("modalFormatTags");
   const roleTagsContainer = document.getElementById("modalRoleTags");
+  const collabLiverTagsContainer = document.getElementById("modalCollabLiverTags");
+  const collabUnitTagsContainer = document.getElementById("modalCollabUnitTags");
 
   if (!modal || !applyButton) return;
 
@@ -78,6 +80,20 @@
     return [...select.options]
       .map(option => option.value)
       .filter(Boolean);
+  }
+
+  function getCsvTagValues(columnName) {
+    const values = new Set();
+
+    allVideos.forEach(video => {
+      String(video[columnName] || "")
+        .split(",")
+        .map(value => value.trim())
+        .filter(Boolean)
+        .forEach(value => values.add(value));
+    });
+
+    return [...values].sort((a, b) => a.localeCompare(b, "ja"));
   }
 
   function getFormatValues() {
@@ -158,9 +174,49 @@
     });
   }
 
+  function getCollabButtonClass(isActive) {
+    return isActive
+      ? "bg-gray-700 text-white px-3 py-1 rounded-full text-xs"
+      : "bg-gray-100 text-gray-700 px-3 py-1 rounded-full text-xs";
+  }
+
+  function renderCollabTagGroup(container, values) {
+    if (!container) return;
+
+    container.innerHTML = "";
+
+    values.forEach(value => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = value;
+
+      const isActive = selectedCollabTag === value;
+      button.className = getCollabButtonClass(isActive);
+      button.addEventListener("click", () => {
+        selectedCollabTag = selectedCollabTag === value ? "" : value;
+        renderCollabTags();
+        applyFilters();
+      });
+
+      container.appendChild(button);
+    });
+  }
+
+  function renderCollabTags() {
+    renderCollabTagGroup(
+      collabLiverTagsContainer,
+      getCsvTagValues("コラボライバー")
+    );
+    renderCollabTagGroup(
+      collabUnitTagsContainer,
+      getCsvTagValues("コラボユニット")
+    );
+  }
+
   function renderMobileTagSections() {
     renderFormatTags();
     renderRoleTags();
+    renderCollabTags();
   }
 
   function resetModalFilters() {

--- a/style.css
+++ b/style.css
@@ -225,3 +225,34 @@ section {
   margin-top: -4px;
   margin-bottom: 4px;
 }
+
+.modal-section-title {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 8px;
+  color: #6b7280;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.modal-section-title::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: #e5e7eb;
+}
+
+.modal-subsection-title {
+  margin-top: 8px;
+  margin-bottom: 4px;
+  color: #9ca3af;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.modal-collab-scroll {
+  max-height: 132px;
+  overflow-y: auto;
+  padding: 8px 4px 8px 0;
+}


### PR DESCRIPTION
## 変更内容
- スマホ絞り込みの各見出しに、右側へ伸びる薄い区切り線を追加しました
- `Collab` セクションを追加しました
- `Collab` の中を `Liver` / `Unit` に分けて表示しました
- コラボタグが増えてもモーダル全体が長くなりすぎないよう、`Collab` セクションだけ枠内スクロールにしました
- `リセット` でCollabの選択も解除されます
- JSの読み込み番号を `?v=15` に更新しました

## 確認してほしいこと
- 見出しの右側に薄い線が入り、境界が見やすくなっていること
- `Collab` の中で `Liver` と `Unit` が分かれて見えること
- コラボライバー / コラボユニットのタグを押すと絞り込みが動くこと
- `Collab` 部分だけスクロールできること
- リセットでCollab条件も解除されること