### PR TITLE
タグ並び替え処理の重さを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
   <li><a href="https://nanaga-kita.com/" class="underline" target="_blank" rel="noopener">Nana Cheer!</a></li>
 </ul>
 
-<p class="mt-6">歌枠のタイムスタンプや曲情報をコメントで掲載してくれてている皆さまに感謝。</p>
+<p class="mt-6">歌枠のタイムスタンプや曲情報をコメントで掲載してくれている皆さまに感謝。</p>
 
  <p id="lastUpdated">最終更新日：--</p>
 </footer>

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
   <li><a href="https://nanaga-kita.com/" class="underline" target="_blank" rel="noopener">Nana Cheer!</a></li>
 </ul>
 
-<p class="mt-6">歌枠のタイムスタンプや曲情報をコメントで掲載してくれている皆さまに感謝。</p>
+<p class="mt-6">歌枠のタイムスタンプや曲情報をコメントで掲載してくれてている皆さまに感謝。</p>
 
  <p id="lastUpdated">最終更新日：--</p>
 </footer>
@@ -226,9 +226,9 @@
   </div>
 </div>
 
-  <script src="./script.js?v=16"></script>
-  <script src="./mobile-filter-modal.js?v=16"></script>
-  <script src="./youtube-stability.js?v=16"></script>
+  <script src="./script.js?v=17"></script>
+  <script src="./mobile-filter-modal.js?v=17"></script>
+  <script src="./youtube-stability.js?v=17"></script>
 
 </body>
 </html>

--- a/mobile-filter-modal.js
+++ b/mobile-filter-modal.js
@@ -177,7 +177,8 @@
   function reorderCategoryTags() {
     if (!categoryTagsContainer) return;
 
-    [...categoryTagsContainer.querySelectorAll("button")].sort((a, b) => {
+    const buttons = [...categoryTagsContainer.querySelectorAll("button")];
+    const sortedButtons = [...buttons].sort((a, b) => {
       const indexA = categoryOrder.indexOf(a.textContent);
       const indexB = categoryOrder.indexOf(b.textContent);
 
@@ -185,7 +186,12 @@
       if (indexA !== -1) return -1;
       if (indexB !== -1) return 1;
       return String(a.textContent).localeCompare(String(b.textContent), "ja");
-    }).forEach(button => {
+    });
+
+    const isAlreadySorted = buttons.every((button, index) => button === sortedButtons[index]);
+    if (isAlreadySorted) return;
+
+    sortedButtons.forEach(button => {
       categoryTagsContainer.appendChild(button);
     });
   }


### PR DESCRIPTION
## 変更内容
- `Style` の並び替え処理が、同じ順番のときは再実行されないようにしました
- タグ生成の監視処理が繰り返し走り続ける可能性を抑えました
- JS 読み込み番号を `?v=17` に更新しました

## 確認してほしいこと
- 絞り込みを開いたときにタグが表示されること
- ページ全体の重さが改善していること
- Style / Format / Riko Part の並び順が前回の希望どおり残っていること