### PR TITLE
絞り込みモーダル表示中の背景スクロールを固定

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,9 +226,9 @@
   </div>
 </div>
 
-  <script src="./script.js?v=17"></script>
-  <script src="./mobile-filter-modal.js?v=17"></script>
-  <script src="./youtube-stability.js?v=17"></script>
+  <script src="./script.js?v=18"></script>
+  <script src="./mobile-filter-modal.js?v=18"></script>
+  <script src="./youtube-stability.js?v=18"></script>
 
 </body>
 </html>

--- a/mobile-filter-modal.js
+++ b/mobile-filter-modal.js
@@ -21,6 +21,7 @@
 
   let filtersBeforeApply = null;
   let sortButtonGroup = null;
+  let lockedScrollY = 0;
 
   function sortByPreferredOrder(values, preferredOrder) {
     return [...values].sort((a, b) => {
@@ -339,7 +340,34 @@
     renderMobileTagSections();
   }
 
+  function lockPageScroll() {
+    if (document.body.dataset.filterScrollLocked === "true") return;
+
+    lockedScrollY = window.scrollY || window.pageYOffset || 0;
+    document.body.dataset.filterScrollLocked = "true";
+    document.body.style.position = "fixed";
+    document.body.style.top = `-${lockedScrollY}px`;
+    document.body.style.left = "0";
+    document.body.style.right = "0";
+    document.body.style.width = "100%";
+    document.body.style.overflow = "hidden";
+  }
+
+  function unlockPageScroll() {
+    if (document.body.dataset.filterScrollLocked !== "true") return;
+
+    document.body.dataset.filterScrollLocked = "";
+    document.body.style.position = "";
+    document.body.style.top = "";
+    document.body.style.left = "";
+    document.body.style.right = "";
+    document.body.style.width = "";
+    document.body.style.overflow = "";
+    window.scrollTo(0, lockedScrollY);
+  }
+
   document.getElementById("openFilterModal")?.addEventListener("click", () => {
+    lockPageScroll();
     configureSortButtons();
     configureCategoryButtons();
     configureDateButtons();
@@ -349,6 +377,8 @@
     observeCategoryTags();
     syncModalControls();
   });
+
+  document.getElementById("closeFilterModal")?.addEventListener("click", unlockPageScroll);
 
   applyButton.addEventListener("click", () => {
     filtersBeforeApply = {
@@ -390,5 +420,6 @@
     renderPlatformTags();
     renderMobileTagSections();
     applyFilters();
+    unlockPageScroll();
   });
 })();


### PR DESCRIPTION
## 変更内容
- スマホの絞り込みモーダルを開いている間、後ろのリストがスクロールしないようにしました
- モーダルを閉じたときに、開く前のスクロール位置へ戻るようにしました
- JS 読み込み番号を `?v=18` に更新しました

## 確認してほしいこと
- 絞り込みを開いた状態で、後ろの動画リストがスクロールしないこと
- モーダル内のスクロールはこれまで通りできること
- キャンセル / 適用後に元の位置へ戻ること