### PR TITLE
スマホ絞り込みに表示件数を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,6 +163,13 @@
     </div>
 
     <!-- モーダル操作 -->
+    <div id="modalResultCount" class="mt-4 text-center text-gray-500" aria-live="polite">
+      <span class="text-xs">全</span>
+      <span id="modalResultTotal" class="text-lg font-semibold text-gray-700">0</span>
+      <span class="text-xs">件中</span>
+      <span id="modalResultVisible" class="text-2xl font-bold text-blue-600">0</span>
+      <span class="text-xs">件表示</span>
+    </div>
     <div class="mt-4 flex justify-between">
       <button id="applyFilters" class="bg-blue-500 text-white px-4 py-2 rounded-md">適用</button>
       <button id="closeFilterModal" class="text-gray-600 hover:text-black px-4 py-2">キャンセル</button>
@@ -226,9 +233,9 @@
   </div>
 </div>
 
-  <script src="./script.js?v=18"></script>
-  <script src="./mobile-filter-modal.js?v=18"></script>
-  <script src="./youtube-stability.js?v=18"></script>
+  <script src="./script.js?v=19"></script>
+  <script src="./mobile-filter-modal.js?v=19"></script>
+  <script src="./youtube-stability.js?v=19"></script>
 
 </body>
 </html>

--- a/mobile-filter-modal.js
+++ b/mobile-filter-modal.js
@@ -12,6 +12,8 @@
   const roleTagsContainer = document.getElementById("modalRoleTags");
   const collabLiverTagsContainer = document.getElementById("modalCollabLiverTags");
   const collabUnitTagsContainer = document.getElementById("modalCollabUnitTags");
+  const resultTotal = document.getElementById("modalResultTotal");
+  const resultVisible = document.getElementById("modalResultVisible");
 
   if (!modal || !applyButton) return;
 
@@ -51,6 +53,18 @@
         ? "bg-blue-600 text-white px-3 py-2 rounded-md text-sm"
         : "bg-blue-100 text-blue-700 px-3 py-2 rounded-md text-sm";
     });
+  }
+
+  function updateModalResultCount() {
+    if (!resultTotal || !resultVisible) return;
+
+    resultTotal.textContent = String(allVideos.length || 0);
+    resultVisible.textContent = String(currentFilteredVideos.length || 0);
+  }
+
+  function applyFiltersAndUpdateCount() {
+    applyFilters();
+    updateModalResultCount();
   }
 
   function configureSortButtons() {
@@ -166,7 +180,7 @@
 
         if (typeSelect) typeSelect.value = "";
         renderFormatTags();
-        applyFilters();
+        applyFiltersAndUpdateCount();
       });
 
       formatTagsContainer.appendChild(button);
@@ -225,7 +239,7 @@
 
         if (roleSelect) roleSelect.value = "";
         renderRoleTags();
-        applyFilters();
+        applyFiltersAndUpdateCount();
       });
 
       roleTagsContainer.appendChild(button);
@@ -255,7 +269,7 @@
       button.addEventListener("click", () => {
         selectedCollabTag = selectedCollabTag === value ? "" : value;
         renderCollabTags();
-        applyFilters();
+        applyFiltersAndUpdateCount();
       });
 
       container.appendChild(button);
@@ -304,7 +318,7 @@
     renderPlatformTags();
     renderMobileTagSections();
     updateSortButtons();
-    applyFilters();
+    applyFiltersAndUpdateCount();
   }
 
   function configureResetButton() {
@@ -338,6 +352,7 @@
     if (typeSelect) typeSelect.value = "";
     updateSortButtons();
     renderMobileTagSections();
+    updateModalResultCount();
   }
 
   function lockPageScroll() {
@@ -419,7 +434,7 @@
     renderDateTags();
     renderPlatformTags();
     renderMobileTagSections();
-    applyFilters();
+    applyFiltersAndUpdateCount();
     unlockPageScroll();
   });
 })();


### PR DESCRIPTION
## 変更内容
- スマホの絞り込みモーダル下部に `全○件中 ○件表示` を追加しました
- 表示中の件数だけ少し大きく、青色で見やすくしました
- タグを押して即時絞り込みされたときに、件数も同時に更新されるようにしました
- JS 読み込み番号を `?v=19` に更新しました

## 確認してほしいこと
- 絞り込みモーダル下部に件数が表示されること
- タグを選ぶたびに表示件数が変わること
- リセット時に件数が全件に戻ること