### PR TITLE
スマホ絞り込み件数を本体件数表示と同期

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,9 +233,9 @@
   </div>
 </div>
 
-  <script src="./script.js?v=19"></script>
-  <script src="./mobile-filter-modal.js?v=19"></script>
-  <script src="./youtube-stability.js?v=19"></script>
+  <script src="./script.js?v=20"></script>
+  <script src="./mobile-filter-modal.js?v=20"></script>
+  <script src="./youtube-stability.js?v=20"></script>
 
 </body>
 </html>

--- a/mobile-filter-modal.js
+++ b/mobile-filter-modal.js
@@ -14,6 +14,7 @@
   const collabUnitTagsContainer = document.getElementById("modalCollabUnitTags");
   const resultTotal = document.getElementById("modalResultTotal");
   const resultVisible = document.getElementById("modalResultVisible");
+  const songCountElement = document.getElementById("songCount");
 
   if (!modal || !applyButton) return;
 
@@ -24,6 +25,7 @@
   let filtersBeforeApply = null;
   let sortButtonGroup = null;
   let lockedScrollY = 0;
+  let isWatchingSongCount = false;
 
   function sortByPreferredOrder(values, preferredOrder) {
     return [...values].sort((a, b) => {
@@ -58,6 +60,14 @@
   function updateModalResultCount() {
     if (!resultTotal || !resultVisible) return;
 
+    const match = songCountElement?.textContent.match(/(\d+)\D+(\d+)/);
+
+    if (match) {
+      resultTotal.textContent = match[1];
+      resultVisible.textContent = match[2];
+      return;
+    }
+
     resultTotal.textContent = String(allVideos.length || 0);
     resultVisible.textContent = String(currentFilteredVideos.length || 0);
   }
@@ -65,6 +75,17 @@
   function applyFiltersAndUpdateCount() {
     applyFilters();
     updateModalResultCount();
+  }
+
+  function watchSongCount() {
+    if (!songCountElement || isWatchingSongCount) return;
+
+    isWatchingSongCount = true;
+    new MutationObserver(updateModalResultCount).observe(songCountElement, {
+      childList: true,
+      characterData: true,
+      subtree: true
+    });
   }
 
   function configureSortButtons() {
@@ -390,6 +411,7 @@
     configureRoleButtons();
     configureResetButton();
     observeCategoryTags();
+    watchSongCount();
     syncModalControls();
   });
 


### PR DESCRIPTION
## 変更内容
- スマホ絞り込みモーダルの件数を、既存の `○曲中 ○曲表示中` 表示から同期する形に変更しました
- 本体側の件数表示が更新されたら、モーダル側の `全○件中 ○件表示` も自動で更新されるようにしました
- JS 読み込み番号を `?v=20` に更新しました

## 確認してほしいこと
- Style / Platform / Time など、どのタグを押してもモーダル下部の件数が変わること
- 元の `○曲中 ○曲表示中` とモーダル下部の数字が一致すること
- 絞り込み自体がこれまで通り動くこと