### PR TITLE
PC絞り込みを開閉式パネルに整理

### DIFF
--- a/desktop-filter-panel.js
+++ b/desktop-filter-panel.js
@@ -1,0 +1,232 @@
+(function () {
+  const toggleButton = document.getElementById("desktopToggleFilters");
+  const panel = document.getElementById("desktopFilterPanel");
+  const sortSelect = document.getElementById("sortOrder");
+  const sortButtons = document.getElementById("desktopSortButtons");
+  const categoryTags = document.getElementById("desktopCategoryTags");
+  const formatTags = document.getElementById("desktopFormatTags");
+  const roleTags = document.getElementById("desktopRoleTags");
+  const collabLiverTags = document.getElementById("desktopCollabLiverTags");
+  const collabUnitTags = document.getElementById("desktopCollabUnitTags");
+
+  if (!toggleButton || !panel) return;
+
+  const sortLabels = {
+    desc: "新しい順 ↓",
+    asc: "古い順 ↑",
+    title: "タイトル順",
+    artist: "アーティスト順"
+  };
+
+  const categoryOrder = ["ソロ", "コラボ", "あやかき"];
+  const formatOrder = ["3D", "Shorts", "歌枠", "ライブ", "Full", "ハイライト", "アカペラ", "企画", "比較"];
+  const roleOrder = ["VOCAL", "DANCE", "CHORUS", "MOVIE", "ILLUSTRATION", "PIANO", "EUPHONIUM", "KALIMBA"];
+
+  function sortByOrder(values, order) {
+    return [...values].sort((a, b) => {
+      const aIndex = order.indexOf(a);
+      const bIndex = order.indexOf(b);
+      if (aIndex !== -1 || bIndex !== -1) {
+        return (aIndex === -1 ? 999 : aIndex) - (bIndex === -1 ? 999 : bIndex);
+      }
+      return String(a).localeCompare(String(b), "ja");
+    });
+  }
+
+  function buttonClass(isActive, color) {
+    const colors = {
+      blue: isActive
+        ? "border border-blue-600 text-white bg-blue-600"
+        : "border border-blue-200 text-blue-700 bg-blue-50 hover:bg-blue-100",
+      purple: isActive
+        ? "border border-purple-600 text-white bg-purple-600"
+        : "border border-purple-200 text-purple-700 bg-purple-50 hover:bg-purple-100",
+      green: isActive
+        ? "border border-green-600 text-white bg-green-600"
+        : "border border-green-200 text-green-700 bg-green-50 hover:bg-green-100",
+      pink: isActive
+        ? "border border-pink-600 text-white bg-pink-600"
+        : "border border-pink-200 text-pink-700 bg-pink-50 hover:bg-pink-100",
+      yellow: isActive
+        ? "border border-yellow-600 text-white bg-yellow-600"
+        : "border border-yellow-200 text-yellow-800 bg-yellow-50 hover:bg-yellow-100",
+      gray: isActive
+        ? "border border-gray-600 text-white bg-gray-600"
+        : "border border-gray-200 text-gray-700 bg-white hover:bg-gray-100"
+    };
+
+    return `${colors[color] || colors.gray} px-4 py-2 rounded-full text-sm font-medium transition`;
+  }
+
+  function createButton(label, isActive, color, onClick) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = buttonClass(isActive, color);
+    button.textContent = label;
+    button.addEventListener("click", onClick);
+    return button;
+  }
+
+  function appendWrap(container, index, breakAfterIndex) {
+    if (index !== breakAfterIndex) return;
+
+    const wrap = document.createElement("div");
+    wrap.className = "basis-full h-0";
+    container.appendChild(wrap);
+  }
+
+  function getSelectValues(selectId) {
+    const select = document.getElementById(selectId);
+    if (!select) return [];
+
+    return [...select.options]
+      .map(option => option.value)
+      .filter(value => value && value !== "all");
+  }
+
+  function getColumnValues(columnName) {
+    const rows = Array.isArray(allVideos) ? allVideos : [];
+    const values = new Set();
+
+    rows.forEach(video => {
+      String(video[columnName] || "")
+        .split(",")
+        .map(value => value.trim())
+        .filter(Boolean)
+        .forEach(value => values.add(value));
+    });
+
+    return [...values];
+  }
+
+  function renderSortButtons() {
+    if (!sortSelect || !sortButtons) return;
+
+    sortButtons.innerHTML = "";
+    [...sortSelect.options].forEach(option => {
+      const value = option.value;
+      const isActive = sortSelect.value === value;
+
+      sortButtons.appendChild(createButton(sortLabels[value] || option.textContent, isActive, "blue", () => {
+        sortSelect.value = value;
+        applyFilters();
+        renderSortButtons();
+      }));
+    });
+  }
+
+  function reorderCategoryTags() {
+    if (!categoryTags || !categoryTags.children.length) return;
+
+    const buttons = [...categoryTags.children];
+    const currentOrder = buttons.map(button => button.textContent.trim()).join(",");
+    const sortedButtons = [...buttons].sort((a, b) => {
+      const aIndex = categoryOrder.indexOf(a.textContent.trim());
+      const bIndex = categoryOrder.indexOf(b.textContent.trim());
+      return (aIndex === -1 ? 999 : aIndex) - (bIndex === -1 ? 999 : bIndex);
+    });
+
+    const sortedOrder = sortedButtons.map(button => button.textContent.trim()).join(",");
+    if (currentOrder === sortedOrder) return;
+
+    sortedButtons.forEach(button => categoryTags.appendChild(button));
+  }
+
+  function renderFormatTags() {
+    if (!formatTags) return;
+
+    const typeValues = getSelectValues("modalTypeFilter");
+    const values = sortByOrder([...new Set(["3D", "Shorts", ...typeValues])], formatOrder);
+
+    formatTags.innerHTML = "";
+    values.forEach((value, index) => {
+      if (value === "3D") {
+        formatTags.appendChild(createButton(value, selected3DTag === "include", "pink", () => {
+          selected3DTag = toggleTagState(selected3DTag);
+          applyFilters();
+          renderFormatTags();
+        }));
+      } else if (value === "Shorts") {
+        formatTags.appendChild(createButton(value, selectedShortsTag === "include", "pink", () => {
+          selectedShortsTag = toggleTagState(selectedShortsTag);
+          applyFilters();
+          renderFormatTags();
+        }));
+      } else {
+        formatTags.appendChild(createButton(value, selectedVideoTypeTags.has(value), "pink", () => {
+          toggleVideoTypeTag(value);
+          applyFilters();
+          renderFormatTags();
+        }));
+      }
+
+      appendWrap(formatTags, index, 3);
+    });
+  }
+
+  function renderRoleTags() {
+    if (!roleTags) return;
+
+    const values = sortByOrder(getSelectValues("modalRoleFilter"), roleOrder);
+    roleTags.innerHTML = "";
+
+    values.forEach((value, index) => {
+      roleTags.appendChild(createButton(value, selectedRoleTag === value, "yellow", () => {
+        selectedRoleTag = selectedRoleTag === value ? "" : value;
+        applyFilters();
+        renderRoleTags();
+      }));
+
+      appendWrap(roleTags, index, 4);
+    });
+  }
+
+  function renderCollabGroup(container, values, color) {
+    if (!container) return;
+
+    container.innerHTML = "";
+    values.sort((a, b) => String(a).localeCompare(String(b), "ja")).forEach(value => {
+      container.appendChild(createButton(value, selectedCollabTag === value, color, () => {
+        selectedCollabTag = selectedCollabTag === value ? "" : value;
+        applyFilters();
+        renderCollabTags();
+      }));
+    });
+  }
+
+  function renderCollabTags() {
+    renderCollabGroup(collabLiverTags, getColumnValues("コラボライバー"), "gray");
+    renderCollabGroup(collabUnitTags, getColumnValues("コラボユニット"), "blue");
+  }
+
+  function renderDesktopPanel() {
+    renderSortButtons();
+    reorderCategoryTags();
+    renderFormatTags();
+    renderRoleTags();
+    renderCollabTags();
+  }
+
+  toggleButton.addEventListener("click", () => {
+    const isHidden = panel.classList.toggle("hidden");
+    const isOpen = !isHidden;
+
+    toggleButton.setAttribute("aria-expanded", String(isOpen));
+    toggleButton.textContent = isOpen ? "閉じる" : "絞り込み";
+
+    if (isOpen) renderDesktopPanel();
+  });
+
+  if (categoryTags) {
+    const observer = new MutationObserver(reorderCategoryTags);
+    observer.observe(categoryTags, { childList: true });
+  }
+
+  const songCount = document.getElementById("songCount");
+  if (songCount) {
+    const observer = new MutationObserver(() => {
+      if (!panel.classList.contains("hidden")) renderDesktopPanel();
+    });
+    observer.observe(songCount, { childList: true, characterData: true, subtree: true });
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -56,26 +56,75 @@
   </button>
 </div>
 
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+    <div class="hidden sm:block max-w-5xl mx-auto">
+      <div class="flex flex-wrap md:flex-nowrap items-center gap-3">
+        <input id="searchInput" type="text" placeholder="曲名・アーティスト・タグ" 
+          class="min-w-0 basis-full md:basis-auto md:flex-1 rounded-md border border-gray-300 px-4 py-2.5 text-sm focus:ring-blue-300 transition duration-200">
+        <button id="desktopToggleFilters" type="button" aria-controls="desktopFilterPanel" aria-expanded="false"
+          class="shrink-0 bg-blue-100 hover:bg-blue-200 text-blue-900 font-medium text-sm px-4 py-2.5 rounded-md transition-all duration-300">
+          絞り込み
+        </button>
+        <button id="resetFilters" class="shrink-0 bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium text-sm px-4 py-2.5 rounded-md transition-all duration-300">リセット</button>
+        <!-- ランダム再生ボタン -->
+        <button id="randomPlayButton" class="shrink-0 bg-green-100 hover:bg-green-200 text-green-900 font-medium text-sm px-4 py-2.5 rounded-md transition-all duration-300">
+          ランダム再生
+        </button>
+      </div>
 
-      <input id="searchInput" type="text" placeholder="曲名・アーティスト・タグ" 
-        class="hidden sm:block col-span-1 sm:col-span-2 rounded-md border border-gray-300 px-3 py-2 text-sm focus:ring-blue-300 transition duration-200">
-<select id="sortOrder" class="hidden sm:block rounded-md border border-gray-300 px-3 py-2 text-sm focus:ring-blue-300 transition duration-200">
-  <option value="desc">新しい順</option>
-  <option value="asc">古い順</option>
-  <option value="title">曲名順</option>
-  <option value="artist">アーティスト順</option>
-</select>
+      <div id="desktopFilterPanel" class="hidden mt-4 rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+        <select id="sortOrder" class="hidden">
+          <option value="desc">新しい順</option>
+          <option value="asc">古い順</option>
+          <option value="title">曲名順</option>
+          <option value="artist">アーティスト順</option>
+        </select>
 
-      <div id="desktopCategoryTags" class="hidden sm:flex flex-wrap gap-2 items-center"></div>
-      <div id="desktopPlatformTags" class="hidden sm:flex flex-wrap gap-2 items-center"></div>
-      <div id="desktopDateTags" class="hidden sm:flex flex-wrap gap-2 items-center"></div>
-      
-      <button id="resetFilters" class="hidden sm:block bg-blue-100 hover:bg-blue-200 text-blue-900 font-medium text-sm px-4 py-2 rounded-md transition-all duration-300">リセット</button>
-          <!-- ランダム再生ボタン -->
-<button id="randomPlayButton" class="hidden sm:block bg-green-100 hover:bg-green-200 text-green-900 font-medium text-sm px-4 py-2 rounded-md transition-all duration-300">
-  ランダム再生
-</button>
+        <div class="space-y-4">
+          <div>
+            <p class="modal-section-title">Sort</p>
+            <div id="desktopSortButtons" class="flex flex-wrap gap-2"></div>
+          </div>
+
+          <div>
+            <p class="modal-section-title">Style</p>
+            <div id="desktopCategoryTags" class="flex flex-wrap gap-2 items-center"></div>
+          </div>
+
+          <div>
+            <p class="modal-section-title">Platform</p>
+            <div id="desktopPlatformTags" class="flex flex-wrap gap-2 items-center"></div>
+          </div>
+
+          <div>
+            <p class="modal-section-title">Time</p>
+            <div id="desktopDateTags" class="flex flex-wrap gap-2 items-center"></div>
+          </div>
+
+          <div>
+            <p class="modal-section-title">Format</p>
+            <div id="desktopFormatTags" class="flex flex-wrap gap-2 items-center"></div>
+          </div>
+
+          <div>
+            <p class="modal-section-title">Riko Part</p>
+            <div id="desktopRoleTags" class="flex flex-wrap gap-2 items-center"></div>
+          </div>
+
+          <div>
+            <p class="modal-section-title">Collab</p>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <p class="modal-subsection-title">Liver</p>
+                <div id="desktopCollabLiverTags" class="modal-collab-scroll flex flex-wrap gap-2 items-start"></div>
+              </div>
+              <div>
+                <p class="modal-subsection-title">Unit</p>
+                <div id="desktopCollabUnitTags" class="modal-collab-scroll flex flex-wrap gap-2 items-start"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 
@@ -233,9 +282,10 @@
   </div>
 </div>
 
-  <script src="./script.js?v=20"></script>
-  <script src="./mobile-filter-modal.js?v=20"></script>
-  <script src="./youtube-stability.js?v=20"></script>
+  <script src="./script.js?v=21"></script>
+  <script src="./mobile-filter-modal.js?v=21"></script>
+  <script src="./desktop-filter-panel.js?v=21"></script>
+  <script src="./youtube-stability.js?v=21"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## 変更内容
- PCの検索欄をコンパクトな検索バーに整理しました
- PCの絞り込みを「絞り込み」ボタンで開閉するパネル形式にしました
- PC側にも Sort / Style / Platform / Time / Format / Riko Part / Collab を並べました
- Format / Riko Part はスマホ側と同じ固定順にしました
- JS読み込み番号を `?v=21` に更新しました

## 確認してほしいこと
- PC幅で検索窓・絞り込み・リセット・ランダム再生が横並びで見えること
- 絞り込みボタンでPC用パネルが開閉すること
- 各タグで絞り込みが動くこと
- スマホ表示は今まで通りモーダルのまま動くこと