### PR TITLE
件数表示と画面の圧迫感を調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./style.css">
+  <link rel="stylesheet" href="./style.css?v=22">
   <script src="https://www.youtube.com/iframe_api"></script>
 </head>
 <body style="background-color: #FFE36C;" class="text-gray-800">
@@ -37,14 +37,14 @@
 </header>
 
   <!-- サイト説明 -->
-  <div class="max-w-4xl mx-auto px-4 mt-4 text-center text-sm text-gray-600">
+  <div class="max-w-4xl mx-auto px-4 mt-2 text-center text-xs sm:text-sm text-gray-600 leading-relaxed">
   にじさんじ所属 司賀りこさんの歌ってみたや歌枠などをまとめた非公式ファンアーカイブです。<br>
   Youtube(歌ってみた、shorts、歌枠) / tiktok を掲載しています。<br>
   tiktokのみ、仕様上youtubeに比べると再生音が大きい為、ご注意ください。<br>
 </div>
 
 <!-- 絞り込み -->
-<section id="filterSection" class="max-w-8xl mx-auto mt-6 mb-6 px-4">
+<section id="filterSection" class="max-w-8xl mx-auto mt-4 mb-4 px-4">
   
 <!-- モバイル用：絞り込み＋ランダム再生を横並び -->
 <div class="flex sm:hidden items-center justify-center gap-2 mt-4 px-4">
@@ -59,19 +59,27 @@
     <div class="hidden sm:block max-w-5xl mx-auto">
       <div class="flex flex-wrap md:flex-nowrap items-center gap-3">
         <input id="searchInput" type="text" placeholder="曲名・アーティスト・タグ" 
-          class="min-w-0 basis-full md:basis-auto md:flex-1 rounded-md border border-gray-300 px-4 py-2.5 text-sm focus:ring-blue-300 transition duration-200">
+          class="min-w-0 basis-full md:basis-auto md:flex-1 rounded-md border border-gray-300 px-4 py-2 text-sm focus:ring-blue-300 transition duration-200">
         <button id="desktopToggleFilters" type="button" aria-controls="desktopFilterPanel" aria-expanded="false"
-          class="shrink-0 bg-blue-100 hover:bg-blue-200 text-blue-900 font-medium text-sm px-4 py-2.5 rounded-md transition-all duration-300">
+          class="shrink-0 bg-blue-100 hover:bg-blue-200 text-blue-900 font-medium text-sm px-4 py-2 rounded-md transition-all duration-300">
           絞り込み
         </button>
-        <button id="resetFilters" class="shrink-0 bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium text-sm px-4 py-2.5 rounded-md transition-all duration-300">リセット</button>
+        <button id="resetFilters" class="shrink-0 bg-gray-100 hover:bg-gray-200 text-gray-800 font-medium text-sm px-4 py-2 rounded-md transition-all duration-300">リセット</button>
         <!-- ランダム再生ボタン -->
-        <button id="randomPlayButton" class="shrink-0 bg-green-100 hover:bg-green-200 text-green-900 font-medium text-sm px-4 py-2.5 rounded-md transition-all duration-300">
+        <button id="randomPlayButton" class="shrink-0 bg-green-100 hover:bg-green-200 text-green-900 font-medium text-sm px-4 py-2 rounded-md transition-all duration-300">
           ランダム再生
         </button>
       </div>
 
-      <div id="desktopFilterPanel" class="hidden mt-4 rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+      <div id="desktopResultCount" class="hidden mt-2 text-center sm:text-right text-gray-500" aria-live="polite">
+        <span class="text-xs">全</span>
+        <span id="desktopResultTotal" class="text-base font-semibold text-gray-700">0</span>
+        <span class="text-xs">件中</span>
+        <span id="desktopResultVisible" class="text-xl font-bold text-blue-600">0</span>
+        <span class="text-xs">件表示</span>
+      </div>
+
+      <div id="desktopFilterPanel" class="hidden mt-3 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
         <select id="sortOrder" class="hidden">
           <option value="desc">新しい順</option>
           <option value="asc">古い順</option>
@@ -79,7 +87,7 @@
           <option value="artist">アーティスト順</option>
         </select>
 
-        <div class="space-y-4">
+        <div class="space-y-3">
           <div>
             <p class="modal-section-title">Sort</p>
             <div id="desktopSortButtons" class="flex flex-wrap gap-2"></div>
@@ -134,7 +142,7 @@
   </div>
 </div>
   
-  <div id="songCount" class="text-center text-sm text-gray-700 mb-4"></div>
+  <div id="songCount" class="sm:hidden text-center text-sm text-gray-700 mb-4"></div>
 
   <!-- 動画一覧 -->
   <main id="videoList" class="max-w-4xl mx-auto px-4 py-8 divide-y divide-gray-200"> 
@@ -246,15 +254,15 @@
 </footer>
  
 <!-- 再生中の曲名とボタンを一つの箱に入れる -->
-<div id="nowPlayingWrapper" class="fixed bottom-0 left-0 w-full bg-blue-100 text-blue-900 z-30">
-  <div id="nowPlaying" class="py-2 text-center font-medium">
+<div id="nowPlayingWrapper" class="hidden fixed bottom-0 left-0 w-full bg-blue-100 text-blue-900 z-30">
+  <div id="nowPlaying" class="py-1 text-center text-sm font-medium">
     <span id="nowPlayingTitle">再生中</span>
   </div>
   
-  <div id="playerControls" class="flex justify-center gap-2 py-2">
-    <button id="prevVideoBtn" class="bg-gray-300 px-3 py-1 rounded">◀ 戻る</button>
-    <button id="nextVideoBtn" class="bg-gray-300 px-3 py-1 rounded">▶ 次へ</button>
-    <button id="randomFromFilteredBtn" class="bg-gray-300 px-3 py-1 rounded">🎲 ランダム</button>
+  <div id="playerControls" class="flex justify-center gap-2 py-1">
+    <button id="prevVideoBtn" class="bg-gray-300 px-3 py-1 rounded text-sm">◀ 戻る</button>
+    <button id="nextVideoBtn" class="bg-gray-300 px-3 py-1 rounded text-sm">▶ 次へ</button>
+    <button id="randomFromFilteredBtn" class="bg-gray-300 px-3 py-1 rounded text-sm">🎲 ランダム</button>
     <button id="randomAutoPlayBtn" class="random-auto-play-btn is-off" type="button" aria-label="ランダム連続再生 OFF">
   <img src="./shuffle_play.svg" alt="" aria-hidden="true">
 </button>
@@ -282,10 +290,11 @@
   </div>
 </div>
 
-  <script src="./script.js?v=21"></script>
-  <script src="./mobile-filter-modal.js?v=21"></script>
-  <script src="./desktop-filter-panel.js?v=21"></script>
-  <script src="./youtube-stability.js?v=21"></script>
+  <script src="./script.js?v=22"></script>
+  <script src="./mobile-filter-modal.js?v=22"></script>
+  <script src="./desktop-filter-panel.js?v=22"></script>
+  <script src="./ui-polish.js?v=22"></script>
+  <script src="./youtube-stability.js?v=22"></script>
 
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -105,8 +105,8 @@ section {
   top: 0px; 
   z-index: 20;  /* ヘッダーより下に配置 */
   background-color: white;
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding-top: 8px;
+  padding-bottom: 8px;
 }
 
     #activeTagChips {
@@ -153,10 +153,10 @@ section {
 
 #nowPlayingWrapper {
   background-color: #e0f2fe;
-  box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 -1px 4px rgba(0, 0, 0, 0.08);
   height: auto; /* 高さを固定値から自動に */
-  padding-top: 4px;
-  padding-bottom: 8px; /* ボタンに余裕を持たせる */
+  padding-top: 2px;
+  padding-bottom: 4px; /* ボタンに余裕を持たせる */
 }
 #videoList .playing {
   background-color: #fffbe6; /* ハイライト色 */
@@ -188,10 +188,10 @@ section {
   background: rgba(0,0,0,0.25);  /* つまみの目印（好みで調整/削除OK） */
 }
 
-    .random-auto-play-btn {
-  width: 40px;
-  height: 40px;
-  border-radius: 12px;
+.random-auto-play-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
   display: grid;
   place-items: center;
   background: transparent;
@@ -201,8 +201,8 @@ section {
 }
 
 .random-auto-play-btn img {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
 }
 
 .random-auto-play-btn.is-off {
@@ -230,7 +230,7 @@ section {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 8px;
+  margin-bottom: 6px;
   color: #6b7280;
   font-size: 12px;
   font-weight: 700;
@@ -252,7 +252,7 @@ section {
 }
 
 .modal-collab-scroll {
-  max-height: 132px;
+  max-height: 116px;
   overflow-y: auto;
-  padding: 8px 4px 8px 0;
+  padding: 4px 4px 4px 0;
 }

--- a/ui-polish.js
+++ b/ui-polish.js
@@ -1,0 +1,51 @@
+(function () {
+  const songCount = document.getElementById("songCount");
+  const desktopResultCount = document.getElementById("desktopResultCount");
+  const desktopResultTotal = document.getElementById("desktopResultTotal");
+  const desktopResultVisible = document.getElementById("desktopResultVisible");
+  const fixedPlayer = document.getElementById("fixedPlayer");
+  const nowPlayingWrapper = document.getElementById("nowPlayingWrapper");
+
+  function syncDesktopResultCount() {
+    if (!songCount || !desktopResultCount || !desktopResultTotal || !desktopResultVisible) return;
+
+    const match = songCount.textContent.match(/(\d+)\D+(\d+)/);
+    if (!match) return;
+
+    desktopResultTotal.textContent = match[1];
+    desktopResultVisible.textContent = match[2];
+    desktopResultCount.classList.remove("hidden");
+  }
+
+  function isFixedPlayerVisible() {
+    if (!fixedPlayer) return false;
+    return getComputedStyle(fixedPlayer).display !== "none";
+  }
+
+  function syncPlayerControlsVisibility() {
+    if (!fixedPlayer || !nowPlayingWrapper) return;
+
+    if (isFixedPlayerVisible()) {
+      nowPlayingWrapper.classList.remove("hidden");
+      requestAnimationFrame(() => {
+        if (typeof adjustFixedPlayerBottom === "function") adjustFixedPlayerBottom();
+      });
+    } else {
+      nowPlayingWrapper.classList.add("hidden");
+      document.body.style.paddingBottom = "0px";
+    }
+  }
+
+  syncDesktopResultCount();
+  syncPlayerControlsVisibility();
+
+  if (songCount) {
+    const countObserver = new MutationObserver(syncDesktopResultCount);
+    countObserver.observe(songCount, { childList: true, characterData: true, subtree: true });
+  }
+
+  if (fixedPlayer) {
+    const playerObserver = new MutationObserver(syncPlayerControlsVisibility);
+    playerObserver.observe(fixedPlayer, { attributes: true, attributeFilter: ["style", "class"] });
+  }
+})();


### PR DESCRIPTION
## 変更内容
- PC側の検索欄近くに `全○件中 ○件表示` を追加しました
- 既存の件数表示はスマホ側だけに残し、PCで二重に出ないようにしました
- ページ上部の説明文と絞り込み周りの余白を少し詰めました
- 絞り込みパネル内の余白とコラボ欄の高さを少し控えめにしました
- 再生前は下部の再生バーを隠し、プレイヤー表示時だけ一緒に出るようにしました
- 再生バーの高さと影を少し軽くしました
- CSS/JSの読み込み番号を `?v=22` に更新しました

## 確認してほしいこと
- PCで検索欄の近くに件数が表示され、絞り込み時に数字が変わること
- スマホ側の件数表示が今まで通り見えること
- アクセス直後に下部の再生バーが出ていないこと
- 動画を再生するとプレイヤーと一緒に再生バーが表示されること
- プレイヤーを閉じると再生バーも消えること
- 上部説明文と絞り込みパネルの圧迫感が少し減っていること