### PR TITLE
PC絞り込みパネルを再生中でも操作しやすくする

### DIFF
--- a/desktop-filter-panel.js
+++ b/desktop-filter-panel.js
@@ -55,7 +55,7 @@
         : "border border-gray-200 text-gray-700 bg-white hover:bg-gray-100"
     };
 
-    return `${colors[color] || colors.gray} px-4 py-2 rounded-full text-sm font-medium transition`;
+    return `${colors[color] || colors.gray} px-3 py-1.5 rounded-full text-sm font-medium transition`;
   }
 
   function createButton(label, isActive, color, onClick) {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./style.css?v=22">
+  <link rel="stylesheet" href="./style.css?v=23">
   <script src="https://www.youtube.com/iframe_api"></script>
 </head>
 <body style="background-color: #FFE36C;" class="text-gray-800">
@@ -290,11 +290,11 @@
   </div>
 </div>
 
-  <script src="./script.js?v=22"></script>
-  <script src="./mobile-filter-modal.js?v=22"></script>
-  <script src="./desktop-filter-panel.js?v=22"></script>
-  <script src="./ui-polish.js?v=22"></script>
-  <script src="./youtube-stability.js?v=22"></script>
+  <script src="./script.js?v=23"></script>
+  <script src="./mobile-filter-modal.js?v=23"></script>
+  <script src="./desktop-filter-panel.js?v=23"></script>
+  <script src="./ui-polish.js?v=23"></script>
+  <script src="./youtube-stability.js?v=23"></script>
 
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -109,6 +109,31 @@ section {
   padding-bottom: 8px;
 }
 
+#desktopFilterPanel {
+  max-height: min(58vh, 620px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
+body.player-visible #desktopFilterPanel {
+  max-height: min(36vh, 380px);
+}
+
+#desktopFilterPanel .modal-collab-scroll {
+  max-height: 96px;
+}
+
+@media (max-height: 820px) {
+  #desktopFilterPanel {
+    max-height: 48vh;
+  }
+
+  body.player-visible #desktopFilterPanel {
+    max-height: 32vh;
+  }
+}
+
     #activeTagChips {
   position: sticky;
   top: 0;

--- a/ui-polish.js
+++ b/ui-polish.js
@@ -26,11 +26,13 @@
     if (!fixedPlayer || !nowPlayingWrapper) return;
 
     if (isFixedPlayerVisible()) {
+      document.body.classList.add("player-visible");
       nowPlayingWrapper.classList.remove("hidden");
       requestAnimationFrame(() => {
         if (typeof adjustFixedPlayerBottom === "function") adjustFixedPlayerBottom();
       });
     } else {
+      document.body.classList.remove("player-visible");
       nowPlayingWrapper.classList.add("hidden");
       document.body.style.paddingBottom = "0px";
     }


### PR DESCRIPTION
## 変更内容
- PCの絞り込みパネルに高さ上限を付け、パネル内スクロールにしました
- 再生中はプレイヤーと重なりにくいよう、絞り込みパネルの高さをさらに控えめにしました
- PC絞り込み内のタグボタンを少し小さくしました
- Collab欄の内部スクロール高さも少し控えめにしました
- CSS/JSの読み込み番号を `?v=23` に更新しました

## 確認してほしいこと
- PCで絞り込みを開いた時、画面全体を大きく押し下げすぎないこと
- 再生中に絞り込みを開いても、パネル内スクロールで下の項目まで触れること
- Sort / Style / Platform / Time / Format / Riko Part / Collab の各タグが今まで通り動くこと
- スマホ側のモーダル表示に変な影響が出ていないこと