### PR TITLE
絞り込みパネル開閉時のアクティブチップ表示を調整

### DIFF
--- a/desktop-filter-panel.js
+++ b/desktop-filter-panel.js
@@ -213,8 +213,12 @@
 
     toggleButton.setAttribute("aria-expanded", String(isOpen));
     toggleButton.textContent = isOpen ? "閉じる" : "絞り込み";
+    document.body.classList.toggle("desktop-filter-open", isOpen);
 
     if (isOpen) renderDesktopPanel();
+    requestAnimationFrame(() => {
+      if (typeof updateActiveTagChipsPosition === "function") updateActiveTagChipsPosition();
+    });
   });
 
   if (categoryTags) {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./style.css?v=23">
+  <link rel="stylesheet" href="./style.css?v=24">
   <script src="https://www.youtube.com/iframe_api"></script>
 </head>
 <body style="background-color: #FFE36C;" class="text-gray-800">
@@ -292,7 +292,7 @@
 
   <script src="./script.js?v=23"></script>
   <script src="./mobile-filter-modal.js?v=23"></script>
-  <script src="./desktop-filter-panel.js?v=23"></script>
+  <script src="./desktop-filter-panel.js?v=24"></script>
   <script src="./ui-polish.js?v=23"></script>
   <script src="./youtube-stability.js?v=23"></script>
 

--- a/style.css
+++ b/style.css
@@ -165,6 +165,13 @@ body.player-visible #desktopFilterPanel {
   display: none;
 }
 
+@media (min-width: 640px) {
+  body.desktop-filter-open #activeTagChips {
+    display: none !important;
+    top: 0 !important;
+  }
+}
+
       /* 固定プレイヤー用のCSS */
   #fixedPlayer {
     display: none; /* 最初は非表示 */


### PR DESCRIPTION
## 変更内容
- PCで絞り込みパネルを開いている間だけアクティブチップを隠すようにしました
- 絞り込みパネルを閉じた時にアクティブチップ位置を再計算するようにしました
- リスト上のタグをクリックした時のアクティブチップ表示は残しています
- CSS/JSの読み込み番号を `?v=24` に更新しました

## 確認してほしいこと
- PCで絞り込みパネルを開いている間、アクティブチップが邪魔にならないこと
- パネルを閉じた後、リスト上のタグをクリックするとアクティブチップが通常位置に出ること
- パネル開閉後にアクティブチップの位置が下にずれたままにならないこと
- スマホ側のモーダル表示に変な影響が出ていないこと