### PR TITLE
絞り込み後のスクロール位置を調整

### DIFF
--- a/filter-scroll-position.js
+++ b/filter-scroll-position.js
@@ -1,0 +1,70 @@
+(function () {
+  const filterSection = document.getElementById("filterSection");
+  const videoList = document.getElementById("videoList");
+  const fixedPlayer = document.getElementById("fixedPlayer");
+
+  if (!filterSection || !videoList) return;
+
+  let shouldScrollAfterListUpdate = false;
+
+  function isPlayerOpen() {
+    return Boolean(
+      fixedPlayer &&
+      getComputedStyle(fixedPlayer).display !== "none"
+    );
+  }
+
+  function scrollToFilterTop() {
+    const targetTop = filterSection.getBoundingClientRect().top + window.scrollY - 8;
+
+    window.scrollTo({
+      top: Math.max(0, targetTop),
+      behavior: "smooth"
+    });
+  }
+
+  function scrollAfterFilterUpdate() {
+    const playingItem = videoList.querySelector(".playing");
+
+    if (isPlayerOpen() && playingItem) {
+      playingItem.scrollIntoView({ behavior: "smooth", block: "center" });
+      return;
+    }
+
+    scrollToFilterTop();
+  }
+
+  document.addEventListener("click", event => {
+    if (
+      event.target.closest("#videoList button") ||
+      event.target.closest("#desktopFilterPanel button") ||
+      event.target.closest("#filterModal button") ||
+      event.target.closest("#activeTagChips button") ||
+      event.target.closest("#resetFilters") ||
+      event.target.closest("#applyFilters")
+    ) {
+      shouldScrollAfterListUpdate = true;
+    }
+  });
+
+  document.addEventListener("input", event => {
+    if (event.target.matches("#searchInput, #modalSearchInput")) {
+      shouldScrollAfterListUpdate = true;
+    }
+  });
+
+  document.addEventListener("change", event => {
+    if (event.target.matches("#sortOrder, #modalSortOrder")) {
+      shouldScrollAfterListUpdate = true;
+    }
+  });
+
+  const observer = new MutationObserver(() => {
+    if (!shouldScrollAfterListUpdate) return;
+
+    shouldScrollAfterListUpdate = false;
+    requestAnimationFrame(scrollAfterFilterUpdate);
+  });
+
+  observer.observe(videoList, { childList: true });
+})();

--- a/index.html
+++ b/index.html
@@ -295,6 +295,7 @@
   <script src="./desktop-filter-panel.js?v=24"></script>
   <script src="./ui-polish.js?v=23"></script>
   <script src="./player-collapse.js?v=25"></script>
+  <script src="./filter-scroll-position.js?v=26"></script>
   <script src="./youtube-stability.js?v=23"></script>
 
 </body>


### PR DESCRIPTION
## 変更内容
- 絞り込み操作後に一覧の表示位置を自動調整する処理を追加しました
- 再生中プレイヤーが開いていて、再生中カードが絞り込み後の一覧に残っている場合は、そのカードへスクロールします
- 再生していない場合、または再生中カードが絞り込み後の一覧にない場合は、絞り込み欄付近へ戻るようにしました
- 既存の大きな `script.js` は触らず、追加の `filter-scroll-position.js` で制御しています

## 確認してほしいこと
- ページ下部にいる状態でタグ絞り込みをした時、上部の絞り込み欄付近へ戻ること
- 再生中に絞り込みをして、再生中の曲が一覧に残っている場合は、そのカードへ移動すること
- 再生中に絞り込みをして、再生中の曲が一覧から外れた場合は、上部へ戻ること
- スマホの絞り込みモーダルでも同じように見やすい位置へ戻ること