### PR TITLE
放送枠名を日付横に表示する

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./style.css?v=24">
+  <link rel="stylesheet" href="./style.css?v=27">
   <script src="https://www.youtube.com/iframe_api"></script>
 </head>
 <body style="background-color: #FFE36C;" class="text-gray-800">
@@ -291,6 +291,7 @@
 </div>
 
   <script src="./script.js?v=23"></script>
+  <script src="./waku-name-display.js?v=27"></script>
   <script src="./mobile-filter-modal.js?v=23"></script>
   <script src="./desktop-filter-panel.js?v=24"></script>
   <script src="./ui-polish.js?v=23"></script>

--- a/style.css
+++ b/style.css
@@ -82,6 +82,17 @@
   white-space: nowrap;
 }
 
+.video-meta > span:first-child {
+  flex: 0 0 auto;
+}
+
+.video-meta-waku {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 
 
 #videoList a:hover {

--- a/waku-name-display.js
+++ b/waku-name-display.js
@@ -1,0 +1,27 @@
+(function () {
+  const originalRenderVideoList = window.renderVideoList;
+
+  if (typeof originalRenderVideoList !== "function") return;
+
+  function addWakuNames(videos) {
+    const items = document.querySelectorAll("#videoList > div");
+
+    items.forEach((item, index) => {
+      const wakuName = String(videos?.[index]?.waku_name || "").trim();
+      if (!wakuName) return;
+
+      const metaRow = item.querySelector(".video-meta");
+      if (!metaRow || metaRow.querySelector(".video-meta-waku")) return;
+
+      const wakuSpan = document.createElement("span");
+      wakuSpan.className = "video-meta-waku";
+      wakuSpan.textContent = wakuName;
+      metaRow.appendChild(wakuSpan);
+    });
+  }
+
+  window.renderVideoList = function renderVideoListWithWakuName(videos) {
+    originalRenderVideoList(videos);
+    addWakuNames(videos);
+  };
+})();


### PR DESCRIPTION
## 変更内容
- スプレッドシート `シート1` の `waku_name` を、動画カードの日付横に表示するようにしました
- 放送枠名は日付と同じ補足情報の温度感で表示し、特別な装飾は入れていません
- 長い放送枠名は1行内で `...` 省略されるようにしました
- 既存の大きな `script.js` は触らず、追加の `waku-name-display.js` で制御しています

## 確認してほしいこと
- `waku_name` が入っている曲で、日付の右隣に放送枠名が表示されること
- `waku_name` が空欄の曲では、今まで通り日付だけに見えること
- 長い放送枠名がカード幅を押し広げず、`...` で省略されること
- 絞り込み・並び替え後も、表示されているカードと放送枠名がずれないこと