### PR TITLE
絞り込みタグの文字サイズをそろえる

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="./style.css?v=31">
+  <link rel="stylesheet" href="./style.css?v=32">
   <script src="https://www.youtube.com/iframe_api"></script>
 </head>
 <body style="background-color: #FFE36C;" class="text-gray-800">

--- a/style.css
+++ b/style.css
@@ -138,6 +138,18 @@ body.player-visible #desktopFilterPanel {
   max-height: 96px;
 }
 
+#desktopSortButtons button,
+#desktopFormatTags button,
+#desktopRoleTags button,
+#desktopCollabLiverTags button,
+#desktopCollabUnitTags button,
+#filterModal [data-sort] {
+  font-size: 0.75rem;
+  line-height: 1rem;
+  font-weight: 500;
+  padding: 0.25rem 0.75rem;
+}
+
 @media (max-height: 820px) {
   #desktopFilterPanel {
     max-height: 48vh;


### PR DESCRIPTION
## 変更内容
- PC版の絞り込みパネルで、Sort / Format / Riko Part / Collab のボタン文字サイズを小さめに統一
- モバイル版のSortボタンも同じ見え方に近づくよう調整
- `style.css` の読み上げ番号を `v=32` に更新

## 確認ポイント
- PC版の絞り込みパネルで、Sort / Format / Riko Part / Collab が Style などに近いサイズ感になっていること
- モバイル版の絞り込みで、Sortの文字だけ大きく見えないこと