### PR TITLE
再生中カードのスクロール位置を調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,6 +290,7 @@ YouTube / TikTok の動画を掲載しています。<br>
 </div>
 
   <script src="./loading-status.js?v=1"></script>
+  <script src="./playing-scroll-position.js?v=1"></script>
   <script src="./script.js?v=23"></script>
   <script src="./waku-name-display.js?v=27"></script>
   <script src="./mobile-filter-modal.js?v=23"></script>

--- a/playing-scroll-position.js
+++ b/playing-scroll-position.js
@@ -1,0 +1,57 @@
+(() => {
+  const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+  function isPlayingCard(element) {
+    return element instanceof Element &&
+      element.classList.contains('playing') &&
+      Boolean(element.closest('#videoList'));
+  }
+
+  function getVisibleFixedHeight(element) {
+    if (!element || element.classList.contains('hidden')) return 0;
+
+    const style = window.getComputedStyle(element);
+    if (style.display === 'none' || style.visibility === 'hidden') return 0;
+
+    const rect = element.getBoundingClientRect();
+    return rect.height > 0 ? rect.height : 0;
+  }
+
+  function getBottomReservedHeight() {
+    const fixedPlayer = document.getElementById('fixedPlayer');
+    const nowPlaying = document.getElementById('nowPlayingWrapper');
+
+    return getVisibleFixedHeight(fixedPlayer) + getVisibleFixedHeight(nowPlaying) + 16;
+  }
+
+  function scrollPlayingCardIntoView(element, options) {
+    const rect = element.getBoundingClientRect();
+    const pageTop = window.scrollY + rect.top;
+    const bottomReserved = getBottomReservedHeight();
+    const topReserved = window.innerWidth < 640 ? 56 : 72;
+    const usableHeight = Math.max(240, window.innerHeight - bottomReserved - topReserved);
+
+    let targetY;
+
+    if (rect.height >= usableHeight) {
+      targetY = pageTop - topReserved;
+    } else {
+      const visualOffset = usableHeight * 0.28;
+      targetY = pageTop - topReserved - visualOffset;
+    }
+
+    window.scrollTo({
+      top: Math.max(0, Math.round(targetY)),
+      behavior: options?.behavior || 'smooth'
+    });
+  }
+
+  Element.prototype.scrollIntoView = function patchedScrollIntoView(options) {
+    if (isPlayingCard(this)) {
+      scrollPlayingCardIntoView(this, options);
+      return;
+    }
+
+    return originalScrollIntoView.call(this, options);
+  };
+})();


### PR DESCRIPTION
## 概要
- 再生中カードへの自動スクロール時に、固定プレイヤーの高さを考慮するようにしました
- 通常の `scrollIntoView` 全体ではなく、動画リスト内の再生中カードだけを対象にしています
- プレイヤー表示中でも、再生中カードが隠れにくい位置へ移動するようにしています

## 確認
- 追加スクリプトの構文チェック済み