### PR TITLE
絞り込みタグの選択状態を見た目に反映

### DIFF
--- a/playing-scroll-position.js
+++ b/playing-scroll-position.js
@@ -55,3 +55,119 @@
     return originalScrollIntoView.call(this, options);
   };
 })();
+
+(() => {
+  const classByGroup = {
+    category: {
+      active: 'bg-blue-600 text-white px-3 py-1 rounded-full text-xs',
+      inactive: 'bg-blue-100 text-blue-700 px-3 py-1 rounded-full text-xs'
+    },
+    platform: {
+      active: 'bg-purple-600 text-white px-3 py-1 rounded-full text-xs',
+      inactive: 'bg-purple-100 text-purple-700 px-3 py-1 rounded-full text-xs'
+    },
+    date: {
+      active: 'bg-green-600 text-white px-3 py-1 rounded-full text-xs',
+      inactive: 'bg-green-100 text-green-700 px-3 py-1 rounded-full text-xs'
+    },
+    format: {
+      active: 'bg-pink-600 text-white px-3 py-1 rounded-full text-xs',
+      inactive: 'bg-pink-100 text-pink-700 px-3 py-1 rounded-full text-xs'
+    },
+    role: {
+      active: 'bg-yellow-400 text-yellow-950 px-3 py-1 rounded-full text-xs',
+      inactive: 'bg-yellow-100 text-yellow-800 px-3 py-1 rounded-full text-xs'
+    },
+    collabLiver: {
+      active: 'bg-gray-600 text-white px-3 py-1 rounded-full text-xs',
+      inactive: 'bg-gray-100 text-gray-700 px-3 py-1 rounded-full text-xs'
+    },
+    collabUnit: {
+      active: 'bg-blue-600 text-white px-3 py-1 rounded-full text-xs',
+      inactive: 'bg-blue-100 text-blue-700 px-3 py-1 rounded-full text-xs'
+    }
+  };
+
+  const panelGroups = [
+    ['modalCategoryTags', 'category'],
+    ['desktopCategoryTags', 'category'],
+    ['modalPlatformTags', 'platform'],
+    ['desktopPlatformTags', 'platform'],
+    ['modalDateTags', 'date'],
+    ['desktopDateTags', 'date'],
+    ['modalFormatTags', 'format'],
+    ['desktopFormatTags', 'format'],
+    ['modalRoleTags', 'role'],
+    ['desktopRoleTags', 'role'],
+    ['modalCollabLiverTags', 'collabLiver'],
+    ['desktopCollabLiverTags', 'collabLiver'],
+    ['modalCollabUnitTags', 'collabUnit'],
+    ['desktopCollabUnitTags', 'collabUnit']
+  ];
+
+  const platformLabels = new Set(['youtube', 'tiktok']);
+
+  function normalizeLabel(value) {
+    return String(value || '').trim().toLowerCase();
+  }
+
+  function getActiveLabels() {
+    return new Set(
+      [...document.querySelectorAll('#activeTagChipsInner button')]
+        .map(button => normalizeLabel(button.textContent))
+        .filter(Boolean)
+    );
+  }
+
+  function setButtonClass(button, group, isActive) {
+    const classes = classByGroup[group];
+    if (!classes) return;
+    button.className = isActive ? classes.active : classes.inactive;
+  }
+
+  function syncPanelButtons(activeLabels) {
+    panelGroups.forEach(([id, group]) => {
+      const container = document.getElementById(id);
+      if (!container) return;
+
+      container.querySelectorAll('button').forEach(button => {
+        const isActive = activeLabels.has(normalizeLabel(button.textContent));
+        setButtonClass(button, group, isActive);
+      });
+    });
+  }
+
+  function syncListPlatformButtons(activeLabels) {
+    document.querySelectorAll('#videoList button').forEach(button => {
+      const label = normalizeLabel(button.textContent);
+      if (!platformLabels.has(label)) return;
+
+      button.className = activeLabels.has(label)
+        ? 'border border-purple-600 text-white bg-purple-600 px-2.5 py-1 rounded-full text-xs hover:bg-purple-600'
+        : 'border border-purple-300 text-purple-700 bg-purple-50 px-2.5 py-1 rounded-full text-xs hover:bg-purple-100';
+    });
+  }
+
+  function syncActiveFilterTags() {
+    const activeLabels = getActiveLabels();
+    syncPanelButtons(activeLabels);
+    syncListPlatformButtons(activeLabels);
+  }
+
+  function scheduleSync() {
+    requestAnimationFrame(syncActiveFilterTags);
+  }
+
+  document.addEventListener('click', scheduleSync, true);
+  document.addEventListener('input', scheduleSync, true);
+  document.addEventListener('change', scheduleSync, true);
+
+  const observer = new MutationObserver(scheduleSync);
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    characterData: true
+  });
+
+  scheduleSync();
+})();


### PR DESCRIPTION
## 概要
- リスト内の Platform タグをクリックした時、選択中は紫のON表示になるようにしました
- リスト上のタグで絞り込んだ後に絞り込みウィンドウを開いた時、現在の絞り込み条件がタグ色に反映されるようにしました
- 既存の絞り込み処理は触らず、アクティブチップの状態を見て表示だけ同期しています

## 確認
- 追加部分の構文チェック済み