### PR TITLE
リストカード側のPlatformタグON表示を補正

### DIFF
--- a/playing-scroll-position.js
+++ b/playing-scroll-position.js
@@ -111,12 +111,28 @@
     return String(value || '').trim().toLowerCase();
   }
 
+  function isPlatformActiveButton(button) {
+    const label = normalizeLabel(button.textContent);
+    return platformLabels.has(label) &&
+      button.classList.contains('bg-purple-600');
+  }
+
   function getActiveLabels() {
-    return new Set(
+    const labels = new Set(
       [...document.querySelectorAll('#activeTagChipsInner button')]
         .map(button => normalizeLabel(button.textContent))
         .filter(Boolean)
     );
+
+    document
+      .querySelectorAll('#modalPlatformTags button, #desktopPlatformTags button')
+      .forEach(button => {
+        if (isPlatformActiveButton(button)) {
+          labels.add(normalizeLabel(button.textContent));
+        }
+      });
+
+    return labels;
   }
 
   function setButtonClass(button, group, isActive) {
@@ -156,6 +172,8 @@
 
   function scheduleSync() {
     requestAnimationFrame(syncActiveFilterTags);
+    setTimeout(syncActiveFilterTags, 0);
+    setTimeout(syncActiveFilterTags, 80);
   }
 
   document.addEventListener('click', scheduleSync, true);
@@ -166,7 +184,9 @@
   observer.observe(document.body, {
     childList: true,
     subtree: true,
-    characterData: true
+    characterData: true,
+    attributes: true,
+    attributeFilter: ['class']
   });
 
   scheduleSync();


### PR DESCRIPTION
## 概要
- リストカード側の `youtube` / `tiktok` タグにも、選択中の紫色ON表示が反映されるよう補正しました
- 検索欄側のPlatformタグがONになっている状態も手がかりにして、カード側の表示へ同期します
- リスト再描画直後にも反映されるよう、同期タイミングを少し強化しました

## 確認
- 追加変更部分の構文チェック済み