### PR TITLE
Platformタグ解除時の色残りを修正

### DIFF
--- a/playing-scroll-position.js
+++ b/playing-scroll-position.js
@@ -113,28 +113,12 @@
     return String(value || '').trim().toLowerCase();
   }
 
-  function isPlatformActiveButton(button) {
-    const label = normalizeLabel(button.textContent);
-    return platformLabels.has(label) &&
-      button.classList.contains('bg-purple-600');
-  }
-
   function getActiveLabels() {
-    const labels = new Set(
+    return new Set(
       [...document.querySelectorAll('#activeTagChipsInner button')]
         .map(button => normalizeLabel(button.textContent))
         .filter(Boolean)
     );
-
-    document
-      .querySelectorAll('#modalPlatformTags button, #desktopPlatformTags button')
-      .forEach(button => {
-        if (isPlatformActiveButton(button)) {
-          labels.add(normalizeLabel(button.textContent));
-        }
-      });
-
-    return labels;
   }
 
   function setButtonClass(button, group, isActive) {


### PR DESCRIPTION
## 概要
- カード側の Youtube / TikTok タグ解除後に、ON色が残ることがある問題を修正しました
- 古いPlatformボタンの色を絞り込み状態として参照しないようにしました
- タグ色同期の軽量化は維持しています

## 確認
- 変更範囲は `playing-scroll-position.js` のPlatform同期判定のみです