### PR TITLE
コラボユニットありのカード表示を薄くする

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@ YouTube / TikTok の動画を掲載しています。<br>
   <script src="./waku-name-display.js?v=27"></script>
   <script src="./mobile-filter-modal.js?v=23"></script>
   <script src="./desktop-filter-panel.js?v=24"></script>
-  <script src="./ui-polish.js?v=23"></script>
+  <script src="./ui-polish.js?v=24"></script>
   <script src="./player-collapse.js?v=25"></script>
   <script src="./filter-scroll-position.js?v=26"></script>
   <script src="./youtube-stability.js?v=23"></script>

--- a/ui-polish.js
+++ b/ui-polish.js
@@ -38,8 +38,86 @@
     }
   }
 
+  function parseCommaTags(value) {
+    return String(value || "")
+      .split(",")
+      .map(v => v.trim())
+      .filter(Boolean);
+  }
+
+  function compactCollabMembers(videos) {
+    const cards = [...document.querySelectorAll("#videoList > div")];
+
+    cards.forEach((card, index) => {
+      const video = videos[index];
+      if (!video) return;
+
+      const collabLivers = parseCommaTags(video["コラボライバー"]);
+      const collabUnits = parseCommaTags(video["コラボユニット"]);
+
+      if (!collabLivers.length || !collabUnits.length) return;
+
+      const rows = [...card.children];
+      const collabRow = rows[rows.length - 1];
+      if (!collabRow || !collabRow.querySelector("button")) return;
+
+      const memberButtons = collabLivers
+        .map(name => {
+          const button = [...collabRow.querySelectorAll("button")]
+            .find(btn => btn.textContent.trim() === name);
+          if (button) button.dataset.collabMember = name;
+          return button;
+        })
+        .filter(Boolean);
+
+      if (!memberButtons.length) return;
+
+      let memberRow = collabRow.querySelector(".collab-member-row");
+      let toggleButton = collabRow.querySelector(".collab-member-toggle");
+
+      if (!memberRow) {
+        memberRow = document.createElement("div");
+        memberRow.className = "collab-member-row basis-full flex flex-wrap gap-1.5";
+      }
+
+      memberButtons.forEach(button => memberRow.appendChild(button));
+      const shouldShowMembers = memberButtons.some(button => button.classList.contains("bg-gray-600"));
+
+      if (!toggleButton) {
+        toggleButton = document.createElement("button");
+        toggleButton.type = "button";
+        toggleButton.className = "collab-member-toggle border border-gray-300 text-gray-600 bg-gray-50 px-2.5 py-1 rounded-full text-xs hover:bg-gray-100 transition";
+      }
+
+      const setMemberRowVisibility = (show) => {
+        memberRow.classList.toggle("hidden", !show);
+        toggleButton.textContent = show ? "メンバーを閉じる" : `メンバー +${collabLivers.length}`;
+      };
+
+      setMemberRowVisibility(shouldShowMembers);
+      toggleButton.onclick = () => setMemberRowVisibility(memberRow.classList.contains("hidden"));
+
+      collabRow.appendChild(toggleButton);
+      collabRow.appendChild(memberRow);
+    });
+  }
+
+  function wrapRenderVideoList() {
+    if (typeof window.renderVideoList !== "function" || window.renderVideoList.isCollabCompactWrapped) {
+      return;
+    }
+
+    const originalRenderVideoList = window.renderVideoList;
+    window.renderVideoList = function wrappedRenderVideoList(videos) {
+      originalRenderVideoList(videos);
+      compactCollabMembers(videos || []);
+    };
+    window.renderVideoList.isCollabCompactWrapped = true;
+  }
+
   syncDesktopResultCount();
   syncPlayerControlsVisibility();
+  wrapRenderVideoList();
 
   if (songCount) {
     const countObserver = new MutationObserver(syncDesktopResultCount);


### PR DESCRIPTION
## 概要
- コラボユニットがあるカードでは、通常表示でコラボライバーを畳むようにしました
- 畳んだメンバーは `メンバー +N` ボタンで展開できます
- コラボライバー名で絞り込み中の場合は、該当カードのメンバー欄を自動で開きます
- `ui-polish.js` の読み込み番号を `v=24` に上げました

## 方針
既存の絞り込み処理は触らず、リスト描画後の見た目調整として実装しています。