### PR TITLE
スマホの再生中カード自動スクロール位置を調整

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,7 +290,7 @@ YouTube / TikTok の動画を掲載しています。<br>
 </div>
 
   <script src="./loading-status.js?v=1"></script>
-  <script src="./playing-scroll-position.js?v=1"></script>
+  <script src="./playing-scroll-position.js?v=2"></script>
   <script src="./script.js?v=23"></script>
   <script src="./waku-name-display.js?v=27"></script>
   <script src="./mobile-filter-modal.js?v=23"></script>

--- a/playing-scroll-position.js
+++ b/playing-scroll-position.js
@@ -24,20 +24,34 @@
     return getVisibleFixedHeight(fixedPlayer) + getVisibleFixedHeight(nowPlaying) + 16;
   }
 
+  function getTopReservedHeight() {
+    const filterSection = document.getElementById('filterSection');
+    const activeTagChips = document.getElementById('activeTagChips');
+
+    return getVisibleFixedHeight(filterSection) + getVisibleFixedHeight(activeTagChips) + 12;
+  }
+
   function scrollPlayingCardIntoView(element, options) {
     const rect = element.getBoundingClientRect();
     const pageTop = window.scrollY + rect.top;
-    const bottomReserved = getBottomReservedHeight();
-    const topReserved = window.innerWidth < 640 ? 56 : 72;
-    const usableHeight = Math.max(240, window.innerHeight - bottomReserved - topReserved);
+    const isMobile = window.innerWidth < 640;
+    const topReserved = isMobile ? getTopReservedHeight() : 72;
 
     let targetY;
 
-    if (rect.height >= usableHeight) {
+    if (isMobile) {
       targetY = pageTop - topReserved;
     } else {
-      const visualOffset = usableHeight * 0.28;
-      targetY = pageTop - topReserved - visualOffset;
+      const bottomReserved = getBottomReservedHeight();
+      const viewportHeight = window.visualViewport?.height || window.innerHeight;
+      const usableHeight = Math.max(240, viewportHeight - bottomReserved - topReserved);
+
+      if (rect.height >= usableHeight) {
+        targetY = pageTop - topReserved;
+      } else {
+        const visualOffset = usableHeight * 0.28;
+        targetY = pageTop - topReserved - visualOffset;
+      }
     }
 
     window.scrollTo({
@@ -48,7 +62,9 @@
 
   Element.prototype.scrollIntoView = function patchedScrollIntoView(options) {
     if (isPlayingCard(this)) {
-      scrollPlayingCardIntoView(this, options);
+      requestAnimationFrame(() => {
+        scrollPlayingCardIntoView(this, options);
+      });
       return;
     }
 


### PR DESCRIPTION
## 概要
- スマホでは再生中カードを画面中央ではなく、上部の固定エリア直下に来るように調整しました
- アクティブチップが出ている場合は、その高さも考慮します
- PC側はこれまで通り、見やすい位置へスクロールする挙動を維持しています
- `playing-scroll-position.js` の読み込み番号を `v=2` に上げました

## 方針
スマホでは固定プレイヤーを大きくできるため、下側の空きから中央寄せを計算するより、上部基準に寄せて安定させています。