### PR TITLE
プレイヤー可変時の動きとトップボタン追従を修正

### DIFF
--- a/loading-status.js
+++ b/loading-status.js
@@ -120,6 +120,7 @@
   function setupBackToTopButton() {
     const SHOW_SCROLL_Y = 420;
     const button = document.createElement('button');
+    let updateFrame = null;
 
     button.type = 'button';
     button.id = 'backToTopButton';
@@ -145,6 +146,7 @@
     }
 
     function updateButtonState() {
+      updateFrame = null;
       const playerOffset = getPlayerOffset();
       const shouldShow = window.scrollY > SHOW_SCROLL_Y;
 
@@ -153,24 +155,42 @@
       button.classList.toggle('is-player-visible', playerOffset > 0);
     }
 
+    function requestButtonUpdate() {
+      if (updateFrame !== null) return;
+      updateFrame = requestAnimationFrame(updateButtonState);
+    }
+
     button.addEventListener('click', () => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
     });
 
-    window.addEventListener('scroll', updateButtonState, { passive: true });
-    window.addEventListener('resize', updateButtonState);
-    window.visualViewport?.addEventListener('resize', updateButtonState);
+    window.addEventListener('scroll', requestButtonUpdate, { passive: true });
+    window.addEventListener('resize', requestButtonUpdate);
+    window.visualViewport?.addEventListener('resize', requestButtonUpdate);
 
     const fixedPlayer = document.getElementById('fixedPlayer');
     if (fixedPlayer) {
-      const observer = new MutationObserver(updateButtonState);
+      const observer = new MutationObserver(requestButtonUpdate);
       observer.observe(fixedPlayer, { attributes: true, attributeFilter: ['style', 'class'] });
+    }
+
+    const playerFrameWrapper = document.getElementById('playerFrameWrapper');
+    if (playerFrameWrapper) {
+      const observer = new MutationObserver(requestButtonUpdate);
+      observer.observe(playerFrameWrapper, { attributes: true, attributeFilter: ['style', 'class'] });
     }
 
     const nowPlayingWrapper = document.getElementById('nowPlayingWrapper');
     if (nowPlayingWrapper) {
-      const observer = new MutationObserver(updateButtonState);
+      const observer = new MutationObserver(requestButtonUpdate);
       observer.observe(nowPlayingWrapper, { attributes: true, childList: true, subtree: true });
+    }
+
+    if (window.ResizeObserver) {
+      const resizeObserver = new ResizeObserver(requestButtonUpdate);
+      if (fixedPlayer) resizeObserver.observe(fixedPlayer);
+      if (playerFrameWrapper) resizeObserver.observe(playerFrameWrapper);
+      if (nowPlayingWrapper) resizeObserver.observe(nowPlayingWrapper);
     }
 
     updateButtonState();

--- a/player-collapse.js
+++ b/player-collapse.js
@@ -51,7 +51,7 @@
     #playerFrameWrapper {
       border-radius: 10px;
       box-shadow: 0 10px 28px rgba(15, 23, 42, 0.24);
-      transition: height 0.22s ease, opacity 0.18s ease, box-shadow 0.18s ease;
+      transition: opacity 0.18s ease, box-shadow 0.18s ease;
     }
 
     .player-window-actions {


### PR DESCRIPTION
## 概要
- プレイヤー可変時に少し遅れて見える原因になっていた高さアニメーションを外しました
- ページトップへ戻るボタンが、プレイヤーの高さ変更にも追従するようにしました
- プレイヤーをドラッグで大きくした時も、トップボタンが被りにくい位置へ再計算されます

## 原因
- `playerFrameWrapper` に `height` のtransitionが入っていたため、ドラッグ中の高さ変更がシームレスではなくなっていました
- トップボタン側はプレイヤー本体の高さ変更を監視していなかったため、可変後の位置更新が遅れていました