### PR TITLE
トップボタンをスクロール中のみ表示しプレイヤーボタンを整える

### DIFF
--- a/loading-status.js
+++ b/loading-status.js
@@ -119,8 +119,12 @@
 
   function setupBackToTopButton() {
     const SHOW_SCROLL_Y = 420;
+    const HIDE_DELAY_MS = 1100;
     const button = document.createElement('button');
     let updateFrame = null;
+    let hideTimer = null;
+    let isScrolling = false;
+    let isPointerOver = false;
 
     button.type = 'button';
     button.id = 'backToTopButton';
@@ -148,7 +152,7 @@
     function updateButtonState() {
       updateFrame = null;
       const playerOffset = getPlayerOffset();
-      const shouldShow = window.scrollY > SHOW_SCROLL_Y;
+      const shouldShow = window.scrollY > SHOW_SCROLL_Y && (isScrolling || isPointerOver);
 
       button.style.setProperty('--back-to-top-player-offset', `${playerOffset}px`);
       button.classList.toggle('is-visible', shouldShow);
@@ -160,11 +164,40 @@
       updateFrame = requestAnimationFrame(updateButtonState);
     }
 
+    function scheduleHide() {
+      window.clearTimeout(hideTimer);
+      if (isPointerOver) return;
+
+      hideTimer = window.setTimeout(() => {
+        isScrolling = false;
+        requestButtonUpdate();
+      }, HIDE_DELAY_MS);
+    }
+
+    function showWhileScrolling() {
+      isScrolling = true;
+      requestButtonUpdate();
+      scheduleHide();
+    }
+
     button.addEventListener('click', () => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
+      scheduleHide();
     });
 
-    window.addEventListener('scroll', requestButtonUpdate, { passive: true });
+    button.addEventListener('pointerenter', () => {
+      isPointerOver = true;
+      isScrolling = true;
+      window.clearTimeout(hideTimer);
+      requestButtonUpdate();
+    });
+
+    button.addEventListener('pointerleave', () => {
+      isPointerOver = false;
+      scheduleHide();
+    });
+
+    window.addEventListener('scroll', showWhileScrolling, { passive: true });
     window.addEventListener('resize', requestButtonUpdate);
     window.visualViewport?.addEventListener('resize', requestButtonUpdate);
 

--- a/player-collapse.js
+++ b/player-collapse.js
@@ -66,30 +66,21 @@
 
     .player-window-button,
     .player-window-icon-button {
-      border: 1px solid rgba(148, 163, 184, 0.45);
-      background: rgba(255, 255, 255, 0.82);
-      color: #374151;
-      box-shadow: 0 2px 8px rgba(15, 23, 42, 0.1);
-      opacity: 0.72;
-      transition: background 0.2s ease, color 0.2s ease, opacity 0.2s ease, transform 0.1s ease;
-    }
-
-    .player-window-button {
+      display: grid;
+      place-items: center;
       width: 28px;
       height: 28px;
       padding: 0;
+      border: 1px solid rgba(148, 163, 184, 0.45);
       border-radius: 9999px;
+      background: rgba(255, 255, 255, 0.82);
+      color: #374151;
+      box-shadow: 0 2px 8px rgba(15, 23, 42, 0.1);
       font-size: 14px;
       font-weight: 700;
       line-height: 1;
-    }
-
-    .player-window-icon-button {
-      width: 28px;
-      height: 28px;
-      border-radius: 9999px;
-      font-size: 14px;
-      font-weight: 700;
+      opacity: 0.72;
+      transition: background 0.2s ease, color 0.2s ease, opacity 0.2s ease, transform 0.1s ease;
     }
 
     .player-window-button:hover,


### PR DESCRIPTION
## 概要
- ページトップへ戻るボタンを、スクロール中だけ表示するようにしました
- スクロール停止後、少し待ってから自動で非表示になります
- ボタンにマウスが乗っている間は消えないようにしています
- プレイヤー右上の `▼` と `×` を同じサイズ・中央揃えの丸ボタンに統一しました

## 補足
- トップボタンの位置調整・プレイヤー追従処理は維持しています
- プレイヤーの開閉・最小化の挙動は変えていません