### PR TITLE
除外チップの文字サイズを調整

### DIFF
--- a/style.css
+++ b/style.css
@@ -187,6 +187,11 @@ body.player-visible #desktopFilterPanel {
   pointer-events: auto;
 }
 
+#activeTagChipsInner .tag-exclusion-chip {
+  font-size: 0.75rem !important;
+  line-height: 1rem !important;
+}
+
 #activeTagChipsInner::-webkit-scrollbar {
   display: none;
 }


### PR DESCRIPTION
## 概要
- 除外条件チップの文字サイズを一段小さくしました
- 挙動は変更せず、見た目だけ通常タグ寄りに整えています

## 確認してほしいこと
- 除外チップの文字だけ大きく見えないこと
- 除外検索の切り替え挙動が変わっていないこと