### PR TITLE
除外状態のタグ文字サイズを揃える

### DIFF
--- a/style.css
+++ b/style.css
@@ -149,6 +149,11 @@ body.player-visible #desktopFilterPanel {
   padding: 0.25rem 0.75rem;
 }
 
+.tag-exclusion-active {
+  font-size: 0.75rem !important;
+  line-height: 1rem !important;
+}
+
 @media (max-height: 820px) {
   #desktopFilterPanel {
     max-height: 48vh;


### PR DESCRIPTION
## 概要
- 除外状態になったタグボタンの文字サイズを `text-xs` 相当に固定しました
- あやかきなどカテゴリタグだけ除外時に大きく見える状態を抑える調整です

## 確認してほしいこと
- `あやかき` を除外状態にしたとき、文字サイズが大きく見えないこと
- YouTubeなど他の除外タグの見た目が崩れていないこと