### PR TITLE
除外検索ファイルを確実に読み直す

### DIFF
--- a/loading-status.js
+++ b/loading-status.js
@@ -233,7 +233,7 @@
     if (document.querySelector('script[data-tag-exclusion-filter]')) return;
 
     const script = document.createElement('script');
-    script.src = './tag-exclusion.js?v=1';
+    script.src = './tag-exclusion.js?v=2';
     script.defer = true;
     script.dataset.tagExclusionFilter = 'true';
     document.body.appendChild(script);


### PR DESCRIPTION
## 概要
- 除外検索用ファイルの読み込みURLを `tag-exclusion.js?v=2` に更新しました
- ブラウザに古い `tag-exclusion.js?v=1` が残っていて、除外挙動が反映されない可能性への対策です

## 確認してほしいこと
- PR反映後にタグを2回押して除外状態になること
- `Time` / `Format` / `Collab` などの除外も動くこと