### PR TITLE
初回表示時のカードタグ除外を安定化

### DIFF
--- a/loading-status.js
+++ b/loading-status.js
@@ -233,7 +233,7 @@
     if (document.querySelector('script[data-tag-exclusion-filter]')) return;
 
     const script = document.createElement('script');
-    script.src = './tag-exclusion.js?v=2';
+    script.src = './tag-exclusion.js?v=3';
     script.defer = true;
     script.dataset.tagExclusionFilter = 'true';
     document.body.appendChild(script);

--- a/tag-exclusion.js
+++ b/tag-exclusion.js
@@ -23,7 +23,7 @@
     platform: new Set(["youtube", "tiktok"]),
     date: new Set(Object.values(dateLabelToValue)),
     format: new Set(),
-    role: new Set(),
+    role: new Set(["VOCAL", "DANCE", "CHORUS", "MOVIE", "ILLUSTRATION", "PIANO", "EUPHONIUM", "KALIMBA"]),
     collab: new Set(),
     flag: new Set(["3D", "Shorts"])
   };
@@ -136,6 +136,36 @@
     });
   }
 
+  function hasClassPart(button, part) {
+    return [...button.classList].some(className => className.includes(part));
+  }
+
+  function inferCardButtonInfo(button, label) {
+    const lowerLabel = label.toLowerCase();
+
+    if (knownTags.flag.has(label)) return { kind: "flag", label };
+    if (knownTags.category.has(label)) return { kind: "category", label };
+    if (knownTags.platform.has(lowerLabel)) return { kind: "platform", label: lowerLabel };
+    if (knownTags.date.has(dateLabelToValue[label] || label)) return { kind: "date", label: dateLabelToValue[label] || label };
+    if (knownTags.role.has(label)) return { kind: "role", label };
+    if (knownTags.format.has(label)) return { kind: "format", label };
+    if (knownTags.collab.has(label)) return { kind: "collab", label };
+
+    if (hasClassPart(button, "pink-")) return { kind: "format", label };
+    if (
+      hasClassPart(button, "rose-") ||
+      hasClassPart(button, "orange-") ||
+      hasClassPart(button, "amber-") ||
+      hasClassPart(button, "lime-") ||
+      hasClassPart(button, "cyan-") ||
+      hasClassPart(button, "sky-")
+    ) {
+      return { kind: "role", label };
+    }
+
+    return { kind: "collab", label };
+  }
+
   function findButtonInfo(button) {
     refreshKnownTags();
 
@@ -150,15 +180,7 @@
 
     if (!button.closest("#videoList")) return null;
 
-    if (knownTags.flag.has(label)) return { kind: "flag", label };
-    if (knownTags.category.has(label)) return { kind: "category", label };
-    if (knownTags.platform.has(label.toLowerCase())) return { kind: "platform", label: label.toLowerCase() };
-    if (knownTags.date.has(dateLabelToValue[label] || label)) return { kind: "date", label: dateLabelToValue[label] || label };
-    if (knownTags.format.has(label)) return { kind: "format", label };
-    if (knownTags.role.has(label)) return { kind: "role", label };
-    if (knownTags.collab.has(label)) return { kind: "collab", label };
-
-    return null;
+    return inferCardButtonInfo(button, label);
   }
 
   function isIncludedButton(button) {


### PR DESCRIPTION
## 概要
- 絞り込みウィンドウを触る前でも、カード側タグの種類を判定できるようにしました
- Format / Riko Part / Collab などをカードの見た目からも判定します
- 除外検索ファイルの読み込みを `v=3` に上げ、修正後のファイルを確実に読み直すようにしました

## 確認してほしいこと
- ページ読み込み直後、全件表示のままカード側のタグを2回押して除外できること
- 絞り込みウィンドウを一度も開かなくてもカード側除外が動くこと
- 絞り込みウィンドウ側の除外挙動が変わっていないこと