### PR TITLE
絞り込み中もアクティブチップを表示

### DIFF
--- a/loading-status.js
+++ b/loading-status.js
@@ -233,7 +233,7 @@
     if (document.querySelector('script[data-tag-exclusion-filter]')) return;
 
     const script = document.createElement('script');
-    script.src = './tag-exclusion.js?v=3';
+    script.src = './tag-exclusion.js?v=4';
     script.defer = true;
     script.dataset.tagExclusionFilter = 'true';
     document.body.appendChild(script);

--- a/tag-exclusion.js
+++ b/tag-exclusion.js
@@ -1,6 +1,7 @@
 (() => {
   const EXCLUDE_BUTTON_CLASS = "tag-exclusion-active";
   const EXCLUDE_CHIP_CLASS = "tag-exclusion-chip";
+  const MOBILE_CHIPS_ID = "mobileModalActiveChips";
   const dateLabelToValue = {
     "最近": "recent",
     "1年以内": "year",
@@ -46,6 +47,7 @@
   let lastRenderedVideos = [];
   let syncFrame = null;
   let isPatchingRender = false;
+  let mobileChipsObserver = null;
 
   const style = document.createElement("style");
   style.textContent = `
@@ -61,6 +63,49 @@
       background: #fff1f2 !important;
       color: #be123c !important;
     }
+
+    @media (min-width: 640px) {
+      body.desktop-filter-open #activeTagChips:not(.hidden) {
+        display: block !important;
+        position: static;
+        top: auto !important;
+        margin-top: -4px;
+      }
+    }
+
+    .filter-modal-title-hidden {
+      display: none !important;
+    }
+
+    .mobile-modal-active-chips {
+      margin-bottom: 12px;
+    }
+
+    .mobile-modal-active-chips.is-empty {
+      display: none;
+    }
+
+    .mobile-modal-active-chips-inner {
+      display: flex;
+      flex-wrap: nowrap;
+      gap: 0.375rem;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
+      border: 1px solid rgba(226, 232, 240, 0.9);
+      background: rgba(248, 250, 252, 0.92);
+      border-radius: 0.75rem;
+      padding: 0.5rem 0.75rem;
+      box-shadow: 0 2px 8px rgba(15, 23, 42, 0.06);
+    }
+
+    .mobile-modal-active-chips-inner::-webkit-scrollbar {
+      display: none;
+    }
+
+    .mobile-modal-active-chips-inner button {
+      flex: 0 0 auto;
+    }
   `;
   document.head.appendChild(style);
 
@@ -74,6 +119,12 @@
   function getDisplayLabel(kind, value) {
     if (kind === "date") return dateValueToLabel[value] || value;
     return value;
+  }
+
+  function getRawButtonLabel(button) {
+    return String(button.dataset.tagExclusionLabel || button.textContent || "")
+      .replace(/^[-−]\s*/, "")
+      .trim();
   }
 
   function splitTags(value) {
@@ -130,7 +181,7 @@
       if (!container) return;
 
       container.querySelectorAll("button").forEach(button => {
-        const label = normalizeLabel(kind, button.textContent);
+        const label = normalizeLabel(kind, getRawButtonLabel(button));
         if (label) knownTags[kind].add(label);
       });
     });
@@ -169,8 +220,8 @@
   function findButtonInfo(button) {
     refreshKnownTags();
 
-    const label = String(button.textContent || "").trim();
-    if (!label || button.closest("#activeTagChips")) return null;
+    const label = getRawButtonLabel(button);
+    if (!label || button.closest("#activeTagChips, #mobileModalActiveChips")) return null;
 
     const container = button.closest(Object.keys(containerKindMap).map(id => `#${id}`).join(","));
     if (container) {
@@ -229,6 +280,52 @@
     return hasExclusions() ? list.filter(passesExclusion) : list;
   }
 
+  function ensureMobileModalChips() {
+    const modalBody = document.querySelector("#filterModal > div");
+    if (!modalBody) return null;
+
+    const title = modalBody.querySelector("h2");
+    if (title) title.classList.add("filter-modal-title-hidden");
+
+    let wrapper = document.getElementById(MOBILE_CHIPS_ID);
+    if (wrapper) return wrapper;
+
+    wrapper = document.createElement("div");
+    wrapper.id = MOBILE_CHIPS_ID;
+    wrapper.className = "mobile-modal-active-chips is-empty";
+    wrapper.innerHTML = '<div class="mobile-modal-active-chips-inner" aria-label="選択中の絞り込み条件"></div>';
+
+    const inner = wrapper.querySelector(".mobile-modal-active-chips-inner");
+    inner.addEventListener("click", event => {
+      const button = event.target.closest("button");
+      if (!button) return;
+
+      event.preventDefault();
+      const text = button.textContent.trim();
+      const sourceButton = [...document.querySelectorAll("#activeTagChipsInner button")]
+        .find(source => source.textContent.trim() === text);
+      sourceButton?.click();
+    });
+
+    if (title) {
+      title.insertAdjacentElement("afterend", wrapper);
+    } else {
+      modalBody.prepend(wrapper);
+    }
+
+    return wrapper;
+  }
+
+  function syncMobileModalChips() {
+    const wrapper = ensureMobileModalChips();
+    const source = document.getElementById("activeTagChipsInner");
+    const target = wrapper?.querySelector(".mobile-modal-active-chips-inner");
+    if (!wrapper || !source || !target) return;
+
+    target.innerHTML = source.innerHTML;
+    wrapper.classList.toggle("is-empty", source.children.length === 0);
+  }
+
   function renderExcludeChips() {
     const activeTagChips = document.getElementById("activeTagChips");
     const activeTagChipsInner = document.getElementById("activeTagChipsInner");
@@ -271,6 +368,27 @@
         window.updateActiveTagChipsPosition();
       }
     }
+
+    syncMobileModalChips();
+  }
+
+  function syncExcludedButtonLabel(button, info, active) {
+    if (!info) return;
+
+    const rawLabel = getRawButtonLabel(button);
+    if (rawLabel && !button.dataset.tagExclusionLabel) {
+      button.dataset.tagExclusionLabel = rawLabel;
+    }
+
+    if (active) {
+      button.textContent = `- ${getDisplayLabel(info.kind, info.label)}`;
+      return;
+    }
+
+    if (button.dataset.tagExclusionLabel) {
+      button.textContent = button.dataset.tagExclusionLabel;
+      delete button.dataset.tagExclusionLabel;
+    }
   }
 
   function syncExcludeButtonStyles() {
@@ -280,6 +398,7 @@
       const info = findButtonInfo(button);
       const active = info ? isExcluded(info.kind, info.label) : false;
       button.classList.toggle(EXCLUDE_BUTTON_CLASS, active);
+      syncExcludedButtonLabel(button, info, active);
       if (active) {
         button.setAttribute("aria-label", `${getDisplayLabel(info.kind, info.label)}を除外中`);
       }
@@ -407,6 +526,15 @@
     }, 0);
   }
 
+  function setupMobileChipsObserver() {
+    const source = document.getElementById("activeTagChipsInner");
+    if (!source || mobileChipsObserver) return;
+
+    mobileChipsObserver = new MutationObserver(syncMobileModalChips);
+    mobileChipsObserver.observe(source, { childList: true, subtree: true, characterData: true });
+    syncMobileModalChips();
+  }
+
   function setup() {
     const patchedList = patchRenderVideoList();
     const patchedChips = patchRenderActiveTagChips();
@@ -416,6 +544,7 @@
       return;
     }
 
+    setupMobileChipsObserver();
     document.addEventListener("click", handleFilteredPlayback, true);
     document.addEventListener("click", handleTagClick, true);
     document.addEventListener("click", handleResetClick, true);


### PR DESCRIPTION
## 概要
- PCで絞り込みパネルを開いている時も、パネル下にアクティブチップを表示するようにしました
- スマホの絞り込みモーダル上部に、1行横スクロールのアクティブチップ欄を追加しました
- 除外状態のタグボタンは `- Shorts` のように、ボタン側にも `-` を表示するようにしました
- 修正反映用に `tag-exclusion.js` の読み込みを `v=4` に更新しました

## 確認してほしいこと
- PCで絞り込みパネルを開いても、選択中/除外中のチップが見えること
- スマホの絞り込みモーダル上部にチップが1行横スクロールで表示されること
- 除外中タグが `- Shorts` のように表示されること
- チップを押して解除できること