### PR TITLE
Timeタグの選択状態を色で表示する

### DIFF
--- a/loading-status.js
+++ b/loading-status.js
@@ -229,14 +229,19 @@
     updateButtonState();
   }
 
-  function loadTagExclusionFilter() {
-    if (document.querySelector('script[data-tag-exclusion-filter]')) return;
+  function loadScriptOnce(src, marker) {
+    if (document.querySelector(`script[data-loader-marker="${marker}"]`)) return;
 
     const script = document.createElement('script');
-    script.src = './tag-exclusion.js?v=4';
+    script.src = src;
     script.defer = true;
-    script.dataset.tagExclusionFilter = 'true';
+    script.dataset.loaderMarker = marker;
     document.body.appendChild(script);
+  }
+
+  function loadTagExclusionFilter() {
+    loadScriptOnce('./tag-exclusion.js?v=4', 'tag-exclusion-filter');
+    loadScriptOnce('./time-tag-active.js?v=1', 'time-tag-active');
   }
 
   const originalFetch = window.fetch.bind(window);

--- a/time-tag-active.js
+++ b/time-tag-active.js
@@ -1,0 +1,103 @@
+(() => {
+  const TIME_CHIP_CLASS = "time-active-chip";
+  const dateLabels = ["最近", "1年以内", "1年以上前"];
+  let selectedTimeLabel = "";
+  let syncFrame = null;
+
+  function getRawLabel(button) {
+    return String(button?.dataset?.tagExclusionLabel || button?.textContent || "")
+      .replace(/^[-−]\s*/, "")
+      .trim();
+  }
+
+  function isTimeButton(button) {
+    return button?.closest?.("#modalDateTags, #desktopDateTags") && dateLabels.includes(getRawLabel(button));
+  }
+
+  function getTimeButtons() {
+    return [...document.querySelectorAll("#modalDateTags button, #desktopDateTags button")]
+      .filter(isTimeButton);
+  }
+
+  function setIncludedStyle(button, active) {
+    if (button.classList.contains("tag-exclusion-active")) return;
+
+    button.classList.toggle("bg-green-600", active);
+    button.classList.toggle("text-white", active);
+    button.classList.toggle("bg-green-100", !active);
+    button.classList.toggle("text-green-700", !active);
+  }
+
+  function syncTimeButtons() {
+    getTimeButtons().forEach(button => {
+      setIncludedStyle(button, getRawLabel(button) === selectedTimeLabel);
+    });
+  }
+
+  function renderTimeChip() {
+    const activeTagChips = document.getElementById("activeTagChips");
+    const activeTagChipsInner = document.getElementById("activeTagChipsInner");
+    if (!activeTagChips || !activeTagChipsInner) return;
+
+    activeTagChipsInner
+      .querySelectorAll(`.${TIME_CHIP_CLASS}`)
+      .forEach(chip => chip.remove());
+
+    if (!selectedTimeLabel) return;
+
+    const chip = document.createElement("button");
+    chip.type = "button";
+    chip.className = `${TIME_CHIP_CLASS} shrink-0 border border-green-300 text-green-700 bg-green-50 px-2.5 py-1 rounded-full text-xs hover:bg-green-100 transition`;
+    chip.textContent = selectedTimeLabel;
+    chip.setAttribute("aria-label", `${selectedTimeLabel}の絞り込みを解除`);
+    chip.addEventListener("click", () => {
+      const sourceButton = getTimeButtons().find(button => getRawLabel(button) === selectedTimeLabel);
+      if (sourceButton) {
+        sourceButton.click();
+      } else {
+        selectedTimeLabel = "";
+        requestSync();
+      }
+    });
+
+    activeTagChipsInner.appendChild(chip);
+    activeTagChips.classList.remove("hidden");
+  }
+
+  function sync() {
+    syncFrame = null;
+    syncTimeButtons();
+    renderTimeChip();
+  }
+
+  function requestSync() {
+    if (syncFrame !== null) return;
+    syncFrame = requestAnimationFrame(sync);
+  }
+
+  document.addEventListener("click", event => {
+    const button = event.target.closest("button");
+    if (!button) return;
+
+    if (button.closest("#resetFilters, #modalResetBtn")) {
+      selectedTimeLabel = "";
+      setTimeout(requestSync, 0);
+      return;
+    }
+
+    if (!isTimeButton(button)) return;
+
+    const label = getRawLabel(button);
+    if (button.classList.contains("tag-exclusion-active")) {
+      selectedTimeLabel = "";
+    } else {
+      selectedTimeLabel = selectedTimeLabel === label ? "" : label;
+    }
+
+    setTimeout(requestSync, 0);
+  }, true);
+
+  const observer = new MutationObserver(requestSync);
+  observer.observe(document.body, { childList: true, subtree: true });
+  requestSync();
+})();


### PR DESCRIPTION
## 内容
- 絞り込みウィンドウのTimeタグを選択した時に、緑の選択色が付くようにしました
- Timeタグの選択状態をアクティブチップにも表示するようにしました
- 除外状態のTimeタグは、これまで通り除外表示を優先するようにしています

## 確認してほしいこと
- `最近` / `1年以内` / `1年以上前` を押した時に、選択中のタグが緑になること
- Timeタグをもう一度押す、またはリセットで色が戻ること
- `- 最近` などの除外表示が崩れていないこと