### PR TITLE
Timeのアクティブチップから絞り込みを解除できるようにする

### DIFF
--- a/loading-status.js
+++ b/loading-status.js
@@ -241,7 +241,7 @@
 
   function loadTagExclusionFilter() {
     loadScriptOnce('./tag-exclusion.js?v=4', 'tag-exclusion-filter');
-    loadScriptOnce('./time-tag-active.js?v=1', 'time-tag-active');
+    loadScriptOnce('./time-tag-active.js?v=2', 'time-tag-active');
   }
 
   const originalFetch = window.fetch.bind(window);

--- a/time-tag-active.js
+++ b/time-tag-active.js
@@ -28,6 +28,16 @@
     button.classList.toggle("text-green-700", !active);
   }
 
+  function clearSelectedTime() {
+    const sourceButton = getTimeButtons().find(button => getRawLabel(button) === selectedTimeLabel);
+    if (sourceButton) {
+      sourceButton.click();
+    } else {
+      selectedTimeLabel = "";
+      requestSync();
+    }
+  }
+
   function syncTimeButtons() {
     getTimeButtons().forEach(button => {
       setIncludedStyle(button, getRawLabel(button) === selectedTimeLabel);
@@ -50,14 +60,10 @@
     chip.className = `${TIME_CHIP_CLASS} shrink-0 border border-green-300 text-green-700 bg-green-50 px-2.5 py-1 rounded-full text-xs hover:bg-green-100 transition`;
     chip.textContent = selectedTimeLabel;
     chip.setAttribute("aria-label", `${selectedTimeLabel}の絞り込みを解除`);
-    chip.addEventListener("click", () => {
-      const sourceButton = getTimeButtons().find(button => getRawLabel(button) === selectedTimeLabel);
-      if (sourceButton) {
-        sourceButton.click();
-      } else {
-        selectedTimeLabel = "";
-        requestSync();
-      }
+    chip.addEventListener("click", event => {
+      event.preventDefault();
+      event.stopPropagation();
+      clearSelectedTime();
     });
 
     activeTagChipsInner.appendChild(chip);
@@ -78,6 +84,13 @@
   document.addEventListener("click", event => {
     const button = event.target.closest("button");
     if (!button) return;
+
+    if (button.classList.contains(TIME_CHIP_CLASS)) {
+      event.preventDefault();
+      event.stopPropagation();
+      clearSelectedTime();
+      return;
+    }
 
     if (button.closest("#resetFilters, #modalResetBtn")) {
       selectedTimeLabel = "";


### PR DESCRIPTION
## 内容
- Timeタグのアクティブチップをクリックした時に、Timeの絞り込みを解除できるようにしました
- モバイル側に複製されたアクティブチップでも同じ解除処理が動くようにしました
- `time-tag-active.js` の読み込み番号を更新しました

## 確認してほしいこと
- `最近` / `1年以内` / `1年以上前` を選んだあと、上部のアクティブチップを押すと解除されること
- PCの絞り込みパネル内でも、スマホの絞り込みウィンドウ内でも解除できること
- 除外チップの動きに影響がないこと