### PR TITLE
Timeの絞り込みチップ解除を安定させる

### DIFF
--- a/loading-status.js
+++ b/loading-status.js
@@ -241,7 +241,7 @@
 
   function loadTagExclusionFilter() {
     loadScriptOnce('./tag-exclusion.js?v=4', 'tag-exclusion-filter');
-    loadScriptOnce('./time-tag-active.js?v=2', 'time-tag-active');
+    loadScriptOnce('./time-tag-active.js?v=3', 'time-tag-active');
   }
 
   const originalFetch = window.fetch.bind(window);

--- a/time-tag-active.js
+++ b/time-tag-active.js
@@ -60,11 +60,6 @@
     chip.className = `${TIME_CHIP_CLASS} shrink-0 border border-green-300 text-green-700 bg-green-50 px-2.5 py-1 rounded-full text-xs hover:bg-green-100 transition`;
     chip.textContent = selectedTimeLabel;
     chip.setAttribute("aria-label", `${selectedTimeLabel}の絞り込みを解除`);
-    chip.addEventListener("click", event => {
-      event.preventDefault();
-      event.stopPropagation();
-      clearSelectedTime();
-    });
 
     activeTagChipsInner.appendChild(chip);
     activeTagChips.classList.remove("hidden");
@@ -87,7 +82,7 @@
 
     if (button.classList.contains(TIME_CHIP_CLASS)) {
       event.preventDefault();
-      event.stopPropagation();
+      event.stopImmediatePropagation();
       clearSelectedTime();
       return;
     }


### PR DESCRIPTION
## 内容
- Timeの絞り込みアクティブチップを押した時、解除処理が二重に走らないようにしました
- モバイル側に複製されたTimeチップでも同じ処理で解除できるようにしています
- `time-tag-active.js` の読み込み番号を更新しました

## 確認してほしいこと
- `最近` / `1年以内` / `1年以上前` を絞り込みで選ぶ
- 表示されたアクティブチップを押す
- Timeの絞り込みが解除され、チップとタグ色が消えること
- 除外状態のチップ解除はこれまで通り動くこと