### PR TITLE
Time絞り込みチップの解除処理を修正する

### DIFF
--- a/loading-status.js
+++ b/loading-status.js
@@ -241,7 +241,7 @@
 
   function loadTagExclusionFilter() {
     loadScriptOnce('./tag-exclusion.js?v=4', 'tag-exclusion-filter');
-    loadScriptOnce('./time-tag-active.js?v=3', 'time-tag-active');
+    loadScriptOnce('./time-tag-active.js?v=4', 'time-tag-active');
   }
 
   const originalFetch = window.fetch.bind(window);

--- a/time-tag-active.js
+++ b/time-tag-active.js
@@ -30,10 +30,11 @@
 
   function clearSelectedTime() {
     const sourceButton = getTimeButtons().find(button => getRawLabel(button) === selectedTimeLabel);
-    if (sourceButton) {
-      sourceButton.click();
+    selectedTimeLabel = "";
+
+    if (sourceButton && typeof sourceButton.onclick === "function") {
+      sourceButton.onclick.call(sourceButton, new MouseEvent("click", { bubbles: false }));
     } else {
-      selectedTimeLabel = "";
       requestSync();
     }
   }


### PR DESCRIPTION
## 内容
- Timeの絞り込みアクティブチップを押した時に、除外検索側のクリック処理へ流れないようにしました
- Timeタグ本来の解除処理だけを呼ぶようにして、絞り込み状態を解除しやすくしました
- `time-tag-active.js` の読み込み番号を更新しました

## 確認してほしいこと
- `最近` / `1年以内` / `1年以上前` を絞り込みで選ぶ
- 表示されたアクティブチップを押す
- 除外状態にならず、Time絞り込みが解除されること
- 除外状態のTimeチップ解除はこれまで通り動くこと