### PR TITLE
Refactor tag filter data attributes

### DIFF
--- a/desktop-filter-panel.js
+++ b/desktop-filter-panel.js
@@ -140,43 +140,39 @@
 
     formatTags.innerHTML = "";
     values.forEach((value, index) => {
+      if (value === "3D") {
+        const button = createButton(value, selected3DTag === "include", "pink", () => {
+          selected3DTag = toggleTagState(selected3DTag);
+          applyFilters();
+          renderFormatTags();
+        });
 
-  if (value === "3D") {  
-    const button = createButton(value, selected3DTag === "include", "pink", () => {
-      selected3DTag = toggleTagState(selected3DTag);
-      applyFilters();
-      renderFormatTags();
-    });
+        button.dataset.filterGroup = "format";
+        button.dataset.filterValue = value;
 
-    button.dataset.filterGroup = "format";
-    button.dataset.filterValue = value;
-
-    formatTags.appendChild(button);
-        
+        formatTags.appendChild(button);
       } else if (value === "Shorts") {
-        
-const button = createButton(value, selectedShortsTag === "include", "pink", () => {
-  selectedShortsTag = toggleTagState(selectedShortsTag);
-  applyFilters();
-  renderFormatTags();
-});
+        const button = createButton(value, selectedShortsTag === "include", "pink", () => {
+          selectedShortsTag = toggleTagState(selectedShortsTag);
+          applyFilters();
+          renderFormatTags();
+        });
 
-button.dataset.filterGroup = "format";
-button.dataset.filterValue = value;
+        button.dataset.filterGroup = "format";
+        button.dataset.filterValue = value;
 
-formatTags.appendChild(button);
-        
+        formatTags.appendChild(button);
       } else {
         const button = createButton(value, selectedVideoTypeTags.has(value), "pink", () => {
-  toggleVideoTypeTag(value);
-  applyFilters();
-  renderFormatTags();
-});
+          toggleVideoTypeTag(value);
+          applyFilters();
+          renderFormatTags();
+        });
 
-button.dataset.filterGroup = "format";
-button.dataset.filterValue = value;
+        button.dataset.filterGroup = "format";
+        button.dataset.filterValue = value;
 
-formatTags.appendChild(button);
+        formatTags.appendChild(button);
       }
 
       appendWrap(formatTags, index, 3);
@@ -190,17 +186,16 @@ formatTags.appendChild(button);
     roleTags.innerHTML = "";
 
     values.forEach((value, index) => {
-   const button = createButton(value, selectedRoleTag === value, "yellow", () => {
-     
-  selectedRoleTag = selectedRoleTag === value ? "" : value;
-  applyFilters();
-  renderRoleTags();
-});
+      const button = createButton(value, selectedRoleTag === value, "yellow", () => {
+        selectedRoleTag = selectedRoleTag === value ? "" : value;
+        applyFilters();
+        renderRoleTags();
+      });
 
-button.dataset.filterGroup = "role";
-button.dataset.filterValue = value;
+      button.dataset.filterGroup = "role";
+      button.dataset.filterValue = value;
 
-roleTags.appendChild(button);
+      roleTags.appendChild(button);
 
       appendWrap(roleTags, index, 4);
     });
@@ -212,15 +207,15 @@ roleTags.appendChild(button);
     container.innerHTML = "";
     values.sort((a, b) => String(a).localeCompare(String(b), "ja")).forEach(value => {
       const button = createButton(value, selectedCollabTag === value, color, () => {
-  selectedCollabTag = selectedCollabTag === value ? "" : value;
-  applyFilters();
-  renderCollabTags();
-});
+        selectedCollabTag = selectedCollabTag === value ? "" : value;
+        applyFilters();
+        renderCollabTags();
+      });
 
-button.dataset.filterGroup = "collab";
-button.dataset.filterValue = value;
+      button.dataset.filterGroup = "collab";
+      button.dataset.filterValue = value;
 
-container.appendChild(button);
+      container.appendChild(button);
     });
   }
 

--- a/desktop-filter-panel.js
+++ b/desktop-filter-panel.js
@@ -140,18 +140,18 @@
 
     formatTags.innerHTML = "";
     values.forEach((value, index) => {
-      if (value === "3D") {
-        
-  const button = createButton(value, selected3DTag === "include", "pink", () => {
-    selected3DTag = toggleTagState(selected3DTag);
-    applyFilters();
-  renderFormatTags();
-});
 
-button.dataset.filterGroup = "format";
-button.dataset.filterValue = value;
+  if (value === "3D") {  
+    const button = createButton(value, selected3DTag === "include", "pink", () => {
+      selected3DTag = toggleTagState(selected3DTag);
+      applyFilters();
+      renderFormatTags();
+    });
 
-formatTags.appendChild(button);
+    button.dataset.filterGroup = "format";
+    button.dataset.filterValue = value;
+
+    formatTags.appendChild(button);
         
       } else if (value === "Shorts") {
         

--- a/desktop-filter-panel.js
+++ b/desktop-filter-panel.js
@@ -141,23 +141,42 @@
     formatTags.innerHTML = "";
     values.forEach((value, index) => {
       if (value === "3D") {
-        formatTags.appendChild(createButton(value, selected3DTag === "include", "pink", () => {
-          selected3DTag = toggleTagState(selected3DTag);
-          applyFilters();
-          renderFormatTags();
-        }));
+        
+  const button = createButton(value, selected3DTag === "include", "pink", () => {
+    selected3DTag = toggleTagState(selected3DTag);
+    applyFilters();
+  renderFormatTags();
+});
+
+button.dataset.filterGroup = "format";
+button.dataset.filterValue = value;
+
+formatTags.appendChild(button);
+        
       } else if (value === "Shorts") {
-        formatTags.appendChild(createButton(value, selectedShortsTag === "include", "pink", () => {
-          selectedShortsTag = toggleTagState(selectedShortsTag);
-          applyFilters();
-          renderFormatTags();
-        }));
+        
+const button = createButton(value, selectedShortsTag === "include", "pink", () => {
+  selectedShortsTag = toggleTagState(selectedShortsTag);
+  applyFilters();
+  renderFormatTags();
+});
+
+button.dataset.filterGroup = "format";
+button.dataset.filterValue = value;
+
+formatTags.appendChild(button);
+        
       } else {
-        formatTags.appendChild(createButton(value, selectedVideoTypeTags.has(value), "pink", () => {
-          toggleVideoTypeTag(value);
-          applyFilters();
-          renderFormatTags();
-        }));
+        const button = createButton(value, selectedVideoTypeTags.has(value), "pink", () => {
+  toggleVideoTypeTag(value);
+  applyFilters();
+  renderFormatTags();
+});
+
+button.dataset.filterGroup = "format";
+button.dataset.filterValue = value;
+
+formatTags.appendChild(button);
       }
 
       appendWrap(formatTags, index, 3);
@@ -171,11 +190,17 @@
     roleTags.innerHTML = "";
 
     values.forEach((value, index) => {
-      roleTags.appendChild(createButton(value, selectedRoleTag === value, "yellow", () => {
-        selectedRoleTag = selectedRoleTag === value ? "" : value;
-        applyFilters();
-        renderRoleTags();
-      }));
+   const button = createButton(value, selectedRoleTag === value, "yellow", () => {
+     
+  selectedRoleTag = selectedRoleTag === value ? "" : value;
+  applyFilters();
+  renderRoleTags();
+});
+
+button.dataset.filterGroup = "role";
+button.dataset.filterValue = value;
+
+roleTags.appendChild(button);
 
       appendWrap(roleTags, index, 4);
     });
@@ -186,11 +211,16 @@
 
     container.innerHTML = "";
     values.sort((a, b) => String(a).localeCompare(String(b), "ja")).forEach(value => {
-      container.appendChild(createButton(value, selectedCollabTag === value, color, () => {
-        selectedCollabTag = selectedCollabTag === value ? "" : value;
-        applyFilters();
-        renderCollabTags();
-      }));
+      const button = createButton(value, selectedCollabTag === value, color, () => {
+  selectedCollabTag = selectedCollabTag === value ? "" : value;
+  applyFilters();
+  renderCollabTags();
+});
+
+button.dataset.filterGroup = "collab";
+button.dataset.filterValue = value;
+
+container.appendChild(button);
     });
   }
 

--- a/mobile-filter-modal.js
+++ b/mobile-filter-modal.js
@@ -180,6 +180,8 @@
       const button = document.createElement("button");
       button.type = "button";
       button.textContent = format;
+      button.dataset.filterGroup = "format";
+      button.dataset.filterValue = format;
 
       const is3D = format === "3D";
       const isShorts = format === "Shorts";
@@ -250,6 +252,8 @@
       const button = document.createElement("button");
       button.type = "button";
       button.textContent = role;
+      button.dataset.filterGroup = "role";
+      button.dataset.filterValue = role;
 
       const isActive = selectedRoleTag === role;
       button.className = isActive
@@ -284,6 +288,8 @@
       const button = document.createElement("button");
       button.type = "button";
       button.textContent = value;
+      button.dataset.filterGroup = "collab";
+      button.dataset.filterValue = value;
 
       const isActive = selectedCollabTag === value;
       button.className = getCollabButtonClass(isActive);

--- a/script.js
+++ b/script.js
@@ -707,7 +707,9 @@ function renderPlatformTags() {
         ? 'bg-purple-600 text-white px-3 py-1 rounded-full text-xs'
         : 'bg-purple-100 text-purple-700 px-3 py-1 rounded-full text-xs';
 
-      btn.textContent = p;
+        btn.textContent = p;
+        btn.dataset.filterGroup = "platform";
+        btn.dataset.filterValue = p;
 
       btn.onclick = () => {
         selectedPlatformTag = selectedPlatformTag === p ? "" : p;
@@ -737,7 +739,9 @@ function renderPlatformTags() {
         ? 'bg-blue-600 text-white px-3 py-1 rounded-full text-xs'
         : 'bg-blue-100 text-blue-700 px-3 py-1 rounded-full text-xs';
 
-      btn.textContent = category;
+        btn.textContent = category;
+        btn.dataset.filterGroup = "category";
+        btn.dataset.filterValue = category;
 
       btn.onclick = () => {
         selectedCategoryTag = selectedCategoryTag === category ? "" : category;
@@ -777,7 +781,9 @@ function renderDateTags() {
         ? 'bg-green-600 text-white px-3 py-1 rounded-full text-xs'
         : 'bg-green-100 text-green-700 px-3 py-1 rounded-full text-xs';
 
-      btn.textContent = opt.label;
+        btn.textContent = opt.label;
+        btn.dataset.filterGroup = "time";
+        btn.dataset.filterValue = opt.value;
 
       btn.onclick = () => {
         selectedDateTag = selectedDateTag === opt.value ? "" : opt.value;

--- a/tag-exclusion.js
+++ b/tag-exclusion.js
@@ -121,6 +121,10 @@
     return value;
   }
 
+  function normalizeFilterGroup(group) {
+    return group === "time" ? "date" : group;
+  }
+
   function getRawButtonLabel(button) {
     return String(button.dataset.tagExclusionLabel || button.textContent || "")
       .replace(/^[-−]\s*/, "")
@@ -222,6 +226,12 @@
 
     const label = getRawButtonLabel(button);
     if (!label || button.closest("#activeTagChips, #mobileModalActiveChips")) return null;
+
+    const dataKind = normalizeFilterGroup(button.dataset.filterGroup);
+    const dataValue = button.dataset.filterValue;
+    if (dataKind && dataValue && excludedTags[dataKind]) {
+      return { kind: dataKind, label: normalizeLabel(dataKind, dataValue) };
+    }
 
     const container = button.closest(Object.keys(containerKindMap).map(id => `#${id}`).join(","));
     if (container) {
@@ -517,7 +527,7 @@
   }
 
   function handleResetClick(event) {
-    const button = event.target.closest("#resetFilters, #modalResetBtn");
+    const button = event.target.closest("#resetFilters, #modalResetBtn, #resetModalFilters");
     if (!button) return;
 
     window.setTimeout(() => {

--- a/time-tag-active.js
+++ b/time-tag-active.js
@@ -1,6 +1,11 @@
 (() => {
   const TIME_CHIP_CLASS = "time-active-chip";
   const dateLabels = ["最近", "1年以内", "1年以上前"];
+  const dateValueToLabel = {
+    recent: "最近",
+    year: "1年以内",
+    old: "1年以上前"
+  };
   let selectedTimeLabel = "";
   let syncFrame = null;
 
@@ -10,7 +15,20 @@
       .trim();
   }
 
+  function getTimeValue(button) {
+    if (button?.dataset?.filterGroup === "time" && button.dataset.filterValue) {
+      return button.dataset.filterValue;
+    }
+
+    return getRawLabel(button);
+  }
+
+  function getDisplayLabel(value) {
+    return dateValueToLabel[value] || value;
+  }
+
   function isTimeButton(button) {
+    if (button?.dataset?.filterGroup === "time") return true;
     return button?.closest?.("#modalDateTags, #desktopDateTags") && dateLabels.includes(getRawLabel(button));
   }
 
@@ -29,7 +47,7 @@
   }
 
   function clearSelectedTime() {
-    const sourceButton = getTimeButtons().find(button => getRawLabel(button) === selectedTimeLabel);
+    const sourceButton = getTimeButtons().find(button => getTimeValue(button) === selectedTimeLabel);
     selectedTimeLabel = "";
 
     if (sourceButton && typeof sourceButton.onclick === "function") {
@@ -41,7 +59,7 @@
 
   function syncTimeButtons() {
     getTimeButtons().forEach(button => {
-      setIncludedStyle(button, getRawLabel(button) === selectedTimeLabel);
+      setIncludedStyle(button, getTimeValue(button) === selectedTimeLabel);
     });
   }
 
@@ -56,11 +74,12 @@
 
     if (!selectedTimeLabel) return;
 
+    const displayLabel = getDisplayLabel(selectedTimeLabel);
     const chip = document.createElement("button");
     chip.type = "button";
     chip.className = `${TIME_CHIP_CLASS} shrink-0 border border-green-300 text-green-700 bg-green-50 px-2.5 py-1 rounded-full text-xs hover:bg-green-100 transition`;
-    chip.textContent = selectedTimeLabel;
-    chip.setAttribute("aria-label", `${selectedTimeLabel}の絞り込みを解除`);
+    chip.textContent = displayLabel;
+    chip.setAttribute("aria-label", `${displayLabel}の絞り込みを解除`);
 
     activeTagChipsInner.appendChild(chip);
     activeTagChips.classList.remove("hidden");
@@ -88,7 +107,7 @@
       return;
     }
 
-    if (button.closest("#resetFilters, #modalResetBtn")) {
+    if (button.closest("#resetFilters, #modalResetBtn, #resetModalFilters")) {
       selectedTimeLabel = "";
       setTimeout(requestSync, 0);
       return;
@@ -96,7 +115,7 @@
 
     if (!isTimeButton(button)) return;
 
-    const label = getRawLabel(button);
+    const label = getTimeValue(button);
     if (button.classList.contains("tag-exclusion-active")) {
       selectedTimeLabel = "";
     } else {


### PR DESCRIPTION
## 変更内容
- mobile-filter-modal.js の Format / Role / Collab タグボタンに data-filter-group / data-filter-value を追加
- tag-exclusion.js で data 属性を優先してタグ種別・値を読むように変更し、既存推測処理は fallback として維持
- time-tag-active.js で data-filter-group="time" / data-filter-value を優先して Time タグを扱うように変更
- desktop-filter-panel.js の崩れていたインデントを整理

## 確認項目
- 今回反映分の差分が mobile-filter-modal.js / tag-exclusion.js / time-tag-active.js / desktop-filter-panel.js の4ファイルであることを確認
- Format / Role / Collab / Time タグの data 属性優先読み取りを確認
- 既存のタグ選択・除外・解除処理は fallback を残して維持

※ このブランチには、この作業前から main との差分として script.js も含まれています。