### PR TITLE
Fix tag exclusion behavior

### DIFF
--- a/playing-scroll-position.js
+++ b/playing-scroll-position.js
@@ -91,7 +91,7 @@
       inactive: 'bg-pink-100 text-pink-700 px-3 py-1 rounded-full text-xs'
     },
     role: {
-      active: 'bg-yellow-400 text-yellow-950 px-3 py-1 rounded-full text-xs',
+      active: 'bg-yellow-400 text-white px-3 py-1 rounded-full text-xs',
       inactive: 'bg-yellow-100 text-yellow-800 px-3 py-1 rounded-full text-xs'
     },
     collabLiver: {

--- a/tag-exclusion.js
+++ b/tag-exclusion.js
@@ -279,8 +279,8 @@
     if (formats.some(tag => excludedTags.format.has(tag))) return false;
     if (roles.some(tag => excludedTags.role.has(tag))) return false;
     if (collabs.some(tag => excludedTags.collab.has(tag))) return false;
-    if (video?.["3D"] === "TRUE" && excludedTags.flag.has("3D")) return false;
-    if (video?.Shorts === "TRUE" && excludedTags.flag.has("Shorts")) return false;
+    if (video?.["3D"] === "TRUE" && (excludedTags.flag.has("3D") || excludedTags.format.has("3D"))) return false;
+    if (video?.Shorts === "TRUE" && (excludedTags.flag.has("Shorts") || excludedTags.format.has("Shorts"))) return false;
 
     return true;
   }


### PR DESCRIPTION
## 変更内容
- 3D / Shorts の除外判定で `excludedTags.flag` に加えて `excludedTags.format` も参照するように修正
- Role タグの active class を `text-white` に戻し、既存の `isIncludedButton(button)` 判定で除外状態へ進めるように修正

## 確認項目
- PC: 3D `401 -> 57 -> 344`
- PC: Shorts `401 -> 152 -> 249`
- PC: VOCAL `401 -> 345 -> 56`
- PC: Format / Collab / Time / Platform / Category の代表タグで既存の除外挙動が変わっていないことを確認
- スマホ: 3D / Shorts / VOCAL で含める・除外が一覧へ反映されることを確認
- `node --check tag-exclusion.js`
- `node --check playing-scroll-position.js`