### PR TITLE
Fix collab tag render ordering

### DIFF
--- a/desktop-filter-panel.js
+++ b/desktop-filter-panel.js
@@ -99,6 +99,14 @@
     return [...values];
   }
 
+  function sortCollabValues(values) {
+    if (typeof window.sortCollabTagValues === "function") {
+      return window.sortCollabTagValues(values);
+    }
+
+    return [...values].sort((a, b) => String(a).localeCompare(String(b), "ja"));
+  }
+
   function renderSortButtons() {
     if (!sortSelect || !sortButtons) return;
 
@@ -205,7 +213,7 @@
     if (!container) return;
 
     container.innerHTML = "";
-    values.sort((a, b) => String(a).localeCompare(String(b), "ja")).forEach(value => {
+    sortCollabValues(values).forEach(value => {
       const button = createButton(value, selectedCollabTag === value, color, () => {
         selectedCollabTag = selectedCollabTag === value ? "" : value;
         applyFilters();
@@ -258,4 +266,8 @@
     });
     observer.observe(songCount, { childList: true, characterData: true, subtree: true });
   }
+
+  window.addEventListener("collabTagOrderReady", () => {
+    if (!panel.classList.contains("hidden")) renderCollabTags();
+  });
 })();

--- a/index.html
+++ b/index.html
@@ -315,13 +315,13 @@ YouTube / TikTok の動画を掲載しています。
   </div>
 </div>
 
-  <script src="./loading-status.js?v=1"></script>
+  <script src="./loading-status.js?v=2"></script>
   <script src="./playing-scroll-position.js?v=2"></script>
   <script src="./script.js?v=23"></script>
   <script src="./waku-name-display.js?v=27"></script>
-  <script src="./mobile-filter-modal.js?v=23"></script>
-  <script src="./desktop-filter-panel.js?v=24"></script>
-  <script src="./ui-polish.js?v=26"></script>
+  <script src="./mobile-filter-modal.js?v=24"></script>
+  <script src="./desktop-filter-panel.js?v=25"></script>
+  <script src="./ui-polish.js?v=27"></script>
   <script src="./player-collapse.js?v=25"></script>
   <script src="./filter-scroll-position.js?v=26"></script>
   <script src="./youtube-stability.js?v=23"></script>

--- a/loading-status.js
+++ b/loading-status.js
@@ -129,9 +129,9 @@
       return [];
     }
 
-    if (data.some(video => !video || !video.title || !video.videoId)) {
+    if (shouldWatch && data.some(video => !video || !video.title || !video.videoId)) {
       console.error('opensheet video list is missing required fields', { url });
-      if (shouldWatch) setStatus(errorMessage, true, true);
+      setStatus(errorMessage, true, true);
       return [];
     }
 

--- a/mobile-filter-modal.js
+++ b/mobile-filter-modal.js
@@ -153,7 +153,15 @@
         .forEach(value => values.add(value));
     });
 
-    return [...values].sort((a, b) => a.localeCompare(b, "ja"));
+    return sortCollabValues([...values]);
+  }
+
+  function sortCollabValues(values) {
+    if (typeof window.sortCollabTagValues === "function") {
+      return window.sortCollabTagValues(values);
+    }
+
+    return [...values].sort((a, b) => String(a).localeCompare(String(b), "ja"));
   }
 
   function getFormatValues() {
@@ -464,5 +472,9 @@
     renderMobileTagSections();
     applyFiltersAndUpdateCount();
     unlockPageScroll();
+  });
+
+  window.addEventListener("collabTagOrderReady", () => {
+    if (!modal.classList.contains("hidden")) renderCollabTags();
   });
 })();

--- a/ui-polish.js
+++ b/ui-polish.js
@@ -16,6 +16,7 @@
   const collabTagObservers = new Map();
   let isSortingCollabTags = false;
   const pendingCollabSortContainers = new Set();
+  let isCollabTagOrderReady = false;
 
   function syncDesktopResultCount() {
     if (!songCount || !desktopResultCount || !desktopResultTotal || !desktopResultVisible) return;
@@ -83,15 +84,65 @@
     return normalizeCollabTag(button.dataset.filterValue || button.textContent);
   }
 
-  function getCollabSortInfo(button) {
-    const label = getCollabButtonLabel(button);
-    const info = collabTagOrder.get(label);
+  function getCollabSortInfoByLabel(label) {
+    const normalizedLabel = normalizeCollabTag(label);
+    const info = collabTagOrder.get(normalizedLabel);
 
     return {
-      label,
+      label: normalizedLabel,
       sortOrder: info?.sortOrder ?? Number.MAX_SAFE_INTEGER,
-      kana: info?.kana || ""
+      kana: info?.kana || "",
+      matched: Boolean(info)
     };
+  }
+
+  function compareCollabLabels(a, b) {
+    const tagA = getCollabSortInfoByLabel(a);
+    const tagB = getCollabSortInfoByLabel(b);
+
+    if (tagA.sortOrder !== tagB.sortOrder) {
+      return tagA.sortOrder - tagB.sortOrder;
+    }
+
+    const kanaCompare = tagA.kana.localeCompare(tagB.kana, "ja");
+    if (kanaCompare !== 0) return kanaCompare;
+
+    return tagA.label.localeCompare(tagB.label, "ja");
+  }
+
+  function sortCollabTagValues(values) {
+    return [...values].sort(compareCollabLabels);
+  }
+
+  function debugCollabTagOrder(values) {
+    const rows = sortCollabTagValues(values).map(value => {
+      const info = getCollabSortInfoByLabel(value);
+      return {
+        tag_name: info.label,
+        sort_order: info.sortOrder === Number.MAX_SAFE_INTEGER ? "" : info.sortOrder,
+        kana: info.kana,
+        matched: info.matched
+      };
+    });
+
+    console.table(rows);
+    return rows;
+  }
+
+  function exposeCollabTagOrder() {
+    window.isCollabTagOrderReady = isCollabTagOrderReady;
+    window.getCollabTagSortInfo = getCollabSortInfoByLabel;
+    window.sortCollabTagValues = sortCollabTagValues;
+    window.debugCollabTagOrder = debugCollabTagOrder;
+  }
+
+  function notifyCollabTagOrderReady() {
+    exposeCollabTagOrder();
+    window.dispatchEvent(new CustomEvent("collabTagOrderReady"));
+  }
+
+  function getCollabSortInfo(button) {
+    return getCollabSortInfoByLabel(getCollabButtonLabel(button));
   }
 
   function sortCollabTagContainer(container) {
@@ -100,19 +151,7 @@
     const buttons = [...container.children].filter(child => child.tagName === "BUTTON");
     if (buttons.length <= 1) return;
 
-    const sorted = [...buttons].sort((a, b) => {
-      const tagA = getCollabSortInfo(a);
-      const tagB = getCollabSortInfo(b);
-
-      if (tagA.sortOrder !== tagB.sortOrder) {
-        return tagA.sortOrder - tagB.sortOrder;
-      }
-
-      const kanaCompare = tagA.kana.localeCompare(tagB.kana, "ja");
-      if (kanaCompare !== 0) return kanaCompare;
-
-      return tagA.label.localeCompare(tagB.label, "ja");
-    });
+    const sorted = [...buttons].sort((a, b) => compareCollabLabels(getCollabButtonLabel(a), getCollabButtonLabel(b)));
 
     const changed = sorted.some((button, index) => button !== buttons[index]);
     if (!changed) return;
@@ -169,6 +208,8 @@
           });
         });
 
+        isCollabTagOrderReady = true;
+        notifyCollabTagOrderReady();
         sortAllCollabTagContainers();
       })
       .catch(() => {
@@ -248,6 +289,7 @@
 
   syncDesktopResultCount();
   syncPlayerControlsVisibility();
+  exposeCollabTagOrder();
   observeCollabTagContainers();
   loadCollabTagOrder();
   wrapRenderVideoList();


### PR DESCRIPTION
## Summary
- sort collab tags through the shared collab_tags sort_order/kana/display-name logic at render time
- re-render PC and modal collab filters when collab tag order data finishes loading
- keep collab_tags loading from being treated as invalid video data and bump script versions

## Checks
- Confirmed GitHub diff contains only loading-status.js, ui-polish.js, desktop-filter-panel.js, mobile-filter-modal.js, and index.html
- Confirmed branch is 1 commit ahead of main