### PR TITLE
Refactor tag color classes into CSS

### DIFF
--- a/desktop-filter-panel.js
+++ b/desktop-filter-panel.js
@@ -33,35 +33,22 @@
     });
   }
 
-  function buttonClass(isActive, color) {
-    const colors = {
-      blue: isActive
-        ? "border border-blue-600 text-white bg-blue-600"
-        : "border border-blue-200 text-blue-700 bg-blue-50 hover:bg-blue-100",
-      purple: isActive
-        ? "border border-purple-600 text-white bg-purple-600"
-        : "border border-purple-200 text-purple-700 bg-purple-50 hover:bg-purple-100",
-      green: isActive
-        ? "border border-green-600 text-white bg-green-600"
-        : "border border-green-200 text-green-700 bg-green-50 hover:bg-green-100",
-      pink: isActive
-        ? "border border-pink-600 text-white bg-pink-600"
-        : "border border-pink-200 text-pink-700 bg-pink-50 hover:bg-pink-100",
-      yellow: isActive
-        ? "border border-yellow-600 text-white bg-yellow-600"
-        : "border border-yellow-200 text-yellow-800 bg-yellow-50 hover:bg-yellow-100",
-      gray: isActive
-        ? "border border-gray-600 text-white bg-gray-600"
-        : "border border-gray-200 text-gray-700 bg-white hover:bg-gray-100"
+  function buttonClass(isActive, kind) {
+    const classes = {
+      sort: "tag-sort",
+      format: "tag-format",
+      role: "tag-role-filter",
+      collabLiver: "tag-collab-liver",
+      collabUnit: "tag-collab-unit"
     };
 
-    return `${colors[color] || colors.gray} px-3 py-1.5 rounded-full text-sm font-medium transition`;
+    return getTagButtonClass(classes[kind] || "tag-collab-liver", isActive, { size: "tag-desktop" });
   }
 
-  function createButton(label, isActive, color, onClick) {
+  function createButton(label, isActive, kind, onClick) {
     const button = document.createElement("button");
     button.type = "button";
-    button.className = buttonClass(isActive, color);
+    button.className = buttonClass(isActive, kind);
     button.textContent = label;
     button.addEventListener("click", onClick);
     return button;
@@ -115,7 +102,7 @@
       const value = option.value;
       const isActive = sortSelect.value === value;
 
-      sortButtons.appendChild(createButton(sortLabels[value] || option.textContent, isActive, "blue", () => {
+      sortButtons.appendChild(createButton(sortLabels[value] || option.textContent, isActive, "sort", () => {
         sortSelect.value = value;
         applyFilters();
         renderSortButtons();
@@ -149,7 +136,7 @@
     formatTags.innerHTML = "";
     values.forEach((value, index) => {
       if (value === "3D") {
-        const button = createButton(value, selected3DTag === "include", "pink", () => {
+        const button = createButton(value, selected3DTag === "include", "format", () => {
           selected3DTag = toggleTagState(selected3DTag);
           applyFilters();
           renderFormatTags();
@@ -160,7 +147,7 @@
 
         formatTags.appendChild(button);
       } else if (value === "Shorts") {
-        const button = createButton(value, selectedShortsTag === "include", "pink", () => {
+        const button = createButton(value, selectedShortsTag === "include", "format", () => {
           selectedShortsTag = toggleTagState(selectedShortsTag);
           applyFilters();
           renderFormatTags();
@@ -171,7 +158,7 @@
 
         formatTags.appendChild(button);
       } else {
-        const button = createButton(value, selectedVideoTypeTags.has(value), "pink", () => {
+        const button = createButton(value, selectedVideoTypeTags.has(value), "format", () => {
           toggleVideoTypeTag(value);
           applyFilters();
           renderFormatTags();
@@ -194,7 +181,7 @@
     roleTags.innerHTML = "";
 
     values.forEach((value, index) => {
-      const button = createButton(value, selectedRoleTag === value, "yellow", () => {
+      const button = createButton(value, selectedRoleTag === value, "role", () => {
         selectedRoleTag = selectedRoleTag === value ? "" : value;
         applyFilters();
         renderRoleTags();
@@ -209,12 +196,12 @@
     });
   }
 
-  function renderCollabGroup(container, values, color) {
+  function renderCollabGroup(container, values, kind) {
     if (!container) return;
 
     container.innerHTML = "";
     sortCollabValues(values).forEach(value => {
-      const button = createButton(value, selectedCollabTag === value, color, () => {
+      const button = createButton(value, selectedCollabTag === value, kind, () => {
         selectedCollabTag = selectedCollabTag === value ? "" : value;
         applyFilters();
         renderCollabTags();
@@ -228,8 +215,8 @@
   }
 
   function renderCollabTags() {
-    renderCollabGroup(collabLiverTags, getColumnValues("コラボライバー"), "gray");
-    renderCollabGroup(collabUnitTags, getColumnValues("コラボユニット"), "blue");
+    renderCollabGroup(collabLiverTags, getColumnValues("コラボライバー"), "collabLiver");
+    renderCollabGroup(collabUnitTags, getColumnValues("コラボユニット"), "collabUnit");
   }
 
   function renderDesktopPanel() {

--- a/mobile-filter-modal.js
+++ b/mobile-filter-modal.js
@@ -51,9 +51,7 @@
 
     sortButtonGroup.querySelectorAll("button[data-sort]").forEach(button => {
       const isActive = button.dataset.sort === (sortSelect.value || "desc");
-      button.className = isActive
-        ? "bg-blue-600 text-white px-3 py-2 rounded-md text-sm"
-        : "bg-blue-100 text-blue-700 px-3 py-2 rounded-md text-sm";
+      button.className = getTagButtonClass("tag-sort", isActive, { size: "tag-modal-sort" });
     });
   }
 
@@ -174,9 +172,7 @@
   }
 
   function getFormatButtonClass(isActive) {
-    return isActive
-      ? "bg-pink-600 text-white px-3 py-1 rounded-full text-xs"
-      : "bg-pink-100 text-pink-700 px-3 py-1 rounded-full text-xs";
+    return getTagButtonClass("tag-format", isActive, { size: "tag-sm" });
   }
 
   function renderFormatTags() {
@@ -264,9 +260,7 @@
       button.dataset.filterValue = role;
 
       const isActive = selectedRoleTag === role;
-      button.className = isActive
-        ? "bg-amber-600 text-white px-3 py-1 rounded-full text-xs"
-        : "bg-amber-100 text-amber-700 px-3 py-1 rounded-full text-xs";
+      button.className = getTagButtonClass("tag-role-filter", isActive, { size: "tag-sm" });
       button.addEventListener("click", () => {
         selectedRoleTag = selectedRoleTag === role ? "" : role;
 
@@ -282,9 +276,7 @@
   }
 
   function getCollabButtonClass(isActive) {
-    return isActive
-      ? "bg-gray-700 text-white px-3 py-1 rounded-full text-xs"
-      : "bg-gray-100 text-gray-700 px-3 py-1 rounded-full text-xs";
+    return getTagButtonClass("tag-collab-liver", isActive, { size: "tag-sm" });
   }
 
   function renderCollabTagGroup(container, values) {

--- a/script.js
+++ b/script.js
@@ -135,8 +135,7 @@ activeTags.forEach(tagData => {
     const chip = document.createElement('button');
     chip.type = 'button';
 
-    chip.className =
-  'shrink-0 border border-gray-300 text-gray-700 bg-gray-50 px-2.5 py-1 rounded-full text-xs hover:bg-gray-100 transition';
+    chip.className = 'tag-button tag-xs tag-active-chip';
 
     chip.textContent = tagData.label;
     
@@ -185,35 +184,39 @@ function escapeHtml(str) {
   }[s]));
 }
 
-function getRoleTagClass(role, isActive = false) {
-  const base = 'px-2.5 py-1 rounded-full text-xs border transition';
+function getTagButtonClass(kind, isActive = false, options = {}) {
+  const classes = ["tag-button", options.size || "tag-xs", kind];
+
+  if (options.valueClass) classes.push(options.valueClass);
+  if (isActive) classes.push(`${kind}-active`);
+
+  return classes.join(" ");
+}
+
+function getStyleTagValueClass(category) {
   const map = {
-    VOCAL: isActive
-      ? 'bg-gray-700 text-white border-gray-700'
-      : 'bg-gray-100 text-gray-800 border-gray-300 hover:bg-gray-200',
-    DANCE: isActive
-      ? 'bg-rose-500 text-white border-rose-500'
-      : 'bg-rose-50 text-rose-700 border-rose-200 hover:bg-rose-100',
-    PIANO: isActive
-      ? 'bg-orange-400 text-white border-orange-400'
-      : 'bg-orange-50 text-orange-700 border-orange-200 hover:bg-orange-100',
-    EUPHONIUM: isActive
-      ? 'bg-amber-400 text-white border-amber-400'
-      : 'bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100',
-    MOVIE: isActive
-      ? 'bg-lime-500 text-white border-lime-500'
-      : 'bg-lime-50 text-lime-700 border-lime-200 hover:bg-lime-100',
-    CHORUS: isActive
-      ? 'bg-sky-500 text-white border-sky-500'
-      : 'bg-sky-50 text-sky-700 border-sky-200 hover:bg-sky-100',
-    ILLUSTRATION: isActive
-      ? 'bg-cyan-500 text-white border-cyan-500'
-      : 'bg-cyan-50 text-cyan-700 border-cyan-200 hover:bg-cyan-100',
+    "ソロ": "tag-style-solo",
+    "コラボ": "tag-style-collab",
+    "あやかき": "tag-style-ayakaki"
   };
 
-  return `${base} ${map[role] || (isActive
-    ? 'bg-blue-600 text-white border-blue-600'
-    : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-100')}`;
+  return map[category] || "tag-style-default";
+}
+
+function getRoleTagClass(role, isActive = false) {
+  const map = {
+    VOCAL: "tag-role-vocal",
+    DANCE: "tag-role-dance",
+    PIANO: "tag-role-piano",
+    EUPHONIUM: "tag-role-euphonium",
+    MOVIE: "tag-role-movie",
+    CHORUS: "tag-role-chorus",
+    ILLUSTRATION: "tag-role-illustration",
+  };
+
+  return getTagButtonClass("tag-role", isActive, {
+    valueClass: map[role] || "tag-role-default"
+  });
 }
 
 
@@ -703,9 +706,7 @@ function renderPlatformTags() {
       const btn = document.createElement('button');
       const isActive = selectedPlatformTag === p;
 
-      btn.className = isActive
-        ? 'bg-purple-600 text-white px-3 py-1 rounded-full text-xs'
-        : 'bg-purple-100 text-purple-700 px-3 py-1 rounded-full text-xs';
+      btn.className = getTagButtonClass("tag-platform", isActive, { size: "tag-sm" });
 
         btn.textContent = p;
         btn.dataset.filterGroup = "platform";
@@ -735,9 +736,7 @@ function renderPlatformTags() {
       const btn = document.createElement('button');
       const isActive = selectedCategoryTag === category;
 
-      btn.className = isActive
-        ? 'bg-blue-600 text-white px-3 py-1 rounded-full text-xs'
-        : 'bg-blue-100 text-blue-700 px-3 py-1 rounded-full text-xs';
+      btn.className = getTagButtonClass("tag-style", isActive, { size: "tag-sm" });
 
         btn.textContent = category;
         btn.dataset.filterGroup = "category";
@@ -777,9 +776,7 @@ function renderDateTags() {
       const btn = document.createElement('button');
       const isActive = selectedDateTag === opt.value;
 
-      btn.className = isActive
-        ? 'bg-green-600 text-white px-3 py-1 rounded-full text-xs'
-        : 'bg-green-100 text-green-700 px-3 py-1 rounded-full text-xs';
+      btn.className = getTagButtonClass("tag-time", isActive, { size: "tag-sm" });
 
         btn.textContent = opt.label;
         btn.dataset.filterGroup = "time";
@@ -874,7 +871,7 @@ function parseYmdToTime(raw) {
   const s = String(raw ?? '').trim();
   if (!s) return 0;
 
-  // YYYY[/-.\u5e74]MM[/-.\u6708]DD(可) 例: 2024/06/30, 2024-6-3, 2024.06.30, 2024年6月30日
+  // YYYY[/-. 年]MM[/-. 月]DD(可) 例: 2024/06/30, 2024-6-3, 2024.06.30, 2024年6月30日
   let m = s.match(/(\d{4})[\/\-.年](\d{1,2})[\/\-.月](\d{1,2})/);
   if (m) {
     const y = +m[1], mo = +m[2], d = +m[3];
@@ -1014,9 +1011,7 @@ if (
 
       const isTypeActive = selectedVideoTypeTags.has(type);
 
-    tag.className = isTypeActive
-      ? 'border border-pink-600 text-white bg-pink-600 px-2.5 py-1 rounded-full text-xs'
-      : 'border border-pink-300 text-pink-700 bg-pink-50 px-2.5 py-1 rounded-full text-xs hover:bg-pink-100';
+    tag.className = getTagButtonClass("tag-format", isTypeActive);
 
     tag.textContent = type;
 
@@ -1036,22 +1031,9 @@ if (category) {
 
   const isCategoryActive = selectedCategoryTag === category;
 
-  const categoryClassMap = {
-    "ソロ": isCategoryActive
-      ? 'border border-blue-600 text-white bg-blue-600 px-2.5 py-1 rounded-full text-xs'
-      : 'border border-blue-300 text-blue-700 bg-blue-50 px-2.5 py-1 rounded-full text-xs hover:bg-blue-100',
-    "コラボ": isCategoryActive
-      ? 'border border-teal-600 text-white bg-teal-600 px-2.5 py-1 rounded-full text-xs'
-      : 'border border-teal-300 text-teal-700 bg-teal-50 px-2.5 py-1 rounded-full text-xs hover:bg-teal-100',
-    "あやかき": isCategoryActive
-      ? 'border border-green-600 text-white bg-green-600 px-2.5 py-1 rounded-full text-xs'
-      : 'border border-green-300 text-green-700 bg-green-50 px-2.5 py-1 rounded-full text-xs hover:bg-green-100'
-  };
-
-  categoryTag.className = categoryClassMap[category] ||
-    (isCategoryActive
-      ? 'border border-gray-600 text-white bg-gray-600 px-2.5 py-1 rounded-full text-xs'
-      : 'border border-gray-300 text-gray-700 bg-gray-50 px-2.5 py-1 rounded-full text-xs hover:bg-gray-100');
+  categoryTag.className = getTagButtonClass("tag-style", isCategoryActive, {
+    valueClass: getStyleTagValueClass(category)
+  });
 
   categoryTag.textContent = category;
 
@@ -1074,9 +1056,7 @@ if (category) {
 
     const isPlatformActive = selectedPlatformTag === platform;
 
-    platformTag.className = isPlatformActive
-      ? 'border border-purple-600 text-white bg-purple-600 px-2.5 py-1 rounded-full text-xs'
-      : 'border border-purple-300 text-purple-700 bg-purple-50 px-2.5 py-1 rounded-full text-xs hover:bg-purple-100';
+    platformTag.className = getTagButtonClass("tag-platform", isPlatformActive);
 
     platformTag.textContent = platform;
 
@@ -1096,9 +1076,7 @@ if (video["3D"] === "TRUE") {
 
   const isInclude = selected3DTag === "include";
 
-  tag3D.className = isInclude
-    ? 'border border-sky-600 text-white bg-sky-600 px-2.5 py-1 rounded-full text-xs'
-    : 'border border-sky-300 text-sky-700 bg-sky-50 px-2.5 py-1 rounded-full text-xs hover:bg-sky-100';
+  tag3D.className = getTagButtonClass("tag-format-3d", isInclude);
 
   tag3D.textContent = '3D';
 
@@ -1117,9 +1095,7 @@ if (video["Shorts"] === "TRUE") {
 
   const isInclude = selectedShortsTag === "include";
 
-  shortsTag.className = isInclude
-    ? 'border border-pink-600 text-white bg-pink-600 px-2.5 py-1 rounded-full text-xs'
-    : 'border border-pink-300 text-pink-700 bg-pink-50 px-2.5 py-1 rounded-full text-xs hover:bg-pink-100';
+  shortsTag.className = getTagButtonClass("tag-format", isInclude);
 
   shortsTag.textContent = 'Shorts';
 
@@ -1176,9 +1152,7 @@ if (collabLivers.length || collabUnits.length) {
     tag.type = 'button';
 
     const isActive = selectedCollabTag === name;
-    tag.className = isActive
-      ? 'border border-gray-500 text-white bg-gray-600 px-2.5 py-1 rounded-full text-xs transition'
-      : 'border border-gray-300 text-gray-700 bg-white px-2.5 py-1 rounded-full text-xs hover:bg-gray-100 transition';
+    tag.className = getTagButtonClass("tag-collab-liver", isActive);
 
     tag.textContent = name;
 
@@ -1195,9 +1169,7 @@ if (collabLivers.length || collabUnits.length) {
     tag.type = 'button';
 
     const isActive = selectedCollabTag === unit;
-    tag.className = isActive
-      ? 'border border-blue-600 text-white bg-blue-600 px-2.5 py-1 rounded-full text-xs transition'
-      : 'border border-blue-300 text-blue-700 bg-blue-50 px-2.5 py-1 rounded-full text-xs hover:bg-blue-100 transition';
+    tag.className = getTagButtonClass("tag-collab-unit", isActive);
 
     tag.textContent = unit;
 

--- a/script.js
+++ b/script.js
@@ -871,7 +871,7 @@ function parseYmdToTime(raw) {
   const s = String(raw ?? '').trim();
   if (!s) return 0;
 
-  // YYYY[/-. 年]MM[/-. 月]DD(可) 例: 2024/06/30, 2024-6-3, 2024.06.30, 2024年6月30日
+  // YYYY[/-.年]MM[/-.月]DD(可) 例: 2024/06/30, 2024-6-3, 2024.06.30, 2024年6月30日
   let m = s.match(/(\d{4})[\/\-.年](\d{1,2})[\/\-.月](\d{1,2})/);
   if (m) {
     const y = +m[1], mo = +m[2], d = +m[3];

--- a/style.css
+++ b/style.css
@@ -154,6 +154,396 @@ body.player-visible #desktopFilterPanel {
   line-height: 1rem !important;
 }
 
+/* ===== Tag buttons ===== */
+.tag-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.tag-xs {
+  padding: 0.25rem 0.625rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.tag-sm {
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
+}
+
+.tag-desktop {
+  padding: 0.375rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+}
+
+.tag-modal-sort {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+.tag-active-chip {
+  flex-shrink: 0;
+  color: #374151;
+  background: #f9fafb;
+  border-color: #d1d5db;
+}
+
+.tag-active-chip:hover {
+  background: #f3f4f6;
+}
+
+.tag-sort,
+.tag-style {
+  color: #1d4ed8;
+  background: #dbeafe;
+}
+
+.tag-sort-active,
+.tag-style-active {
+  color: #fff;
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+.tag-platform {
+  color: #7e22ce;
+  background: #faf5ff;
+  border-color: #d8b4fe;
+}
+
+.tag-sm.tag-platform {
+  background: #f3e8ff;
+  border-color: transparent;
+}
+
+.tag-platform-active {
+  color: #fff;
+  background: #9333ea;
+  border-color: #9333ea;
+}
+
+.tag-time {
+  color: #15803d;
+  background: #dcfce7;
+}
+
+.tag-time-active {
+  color: #fff;
+  background: #16a34a;
+  border-color: #16a34a;
+}
+
+.tag-format {
+  color: #be185d;
+  background: #fdf2f8;
+  border-color: #f9a8d4;
+}
+
+.tag-sm.tag-format {
+  background: #fce7f3;
+  border-color: transparent;
+}
+
+.tag-desktop.tag-format {
+  background: #fdf2f8;
+  border-color: #fbcfe8;
+}
+
+.tag-format-active {
+  color: #fff;
+  background: #db2777;
+  border-color: #db2777;
+}
+
+.tag-format-3d {
+  color: #0369a1;
+  background: #f0f9ff;
+  border-color: #7dd3fc;
+}
+
+.tag-format-3d-active {
+  color: #fff;
+  background: #0284c7;
+  border-color: #0284c7;
+}
+
+.tag-role-filter {
+  color: #b45309;
+  background: #fef3c7;
+}
+
+.tag-role-filter-active {
+  color: #fff;
+  background: #d97706;
+  border-color: #d97706;
+}
+
+.tag-desktop.tag-role-filter {
+  color: #854d0e;
+  background: #fefce8;
+  border-color: #fef08a;
+}
+
+.tag-desktop.tag-role-filter.tag-role-filter-active {
+  color: #fff;
+  background: #ca8a04;
+  border-color: #ca8a04;
+}
+
+.tag-collab-liver {
+  color: #374151;
+  background: #fff;
+  border-color: #d1d5db;
+}
+
+.tag-sm.tag-collab-liver {
+  background: #f3f4f6;
+  border-color: transparent;
+}
+
+.tag-desktop.tag-collab-liver {
+  background: #fff;
+  border-color: #e5e7eb;
+}
+
+.tag-collab-liver-active {
+  color: #fff;
+  background: #4b5563;
+  border-color: #6b7280;
+}
+
+.tag-sm.tag-collab-liver.tag-collab-liver-active {
+  background: #374151;
+  border-color: #374151;
+}
+
+.tag-collab-unit {
+  color: #1d4ed8;
+  background: #eff6ff;
+  border-color: #93c5fd;
+}
+
+.tag-desktop.tag-collab-unit {
+  border-color: #bfdbfe;
+}
+
+.tag-collab-unit-active {
+  color: #fff;
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+.tag-style-solo {
+  color: #1d4ed8;
+  background: #eff6ff;
+  border-color: #93c5fd;
+}
+
+.tag-style-solo.tag-style-active {
+  color: #fff;
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+.tag-style-collab {
+  color: #0f766e;
+  background: #f0fdfa;
+  border-color: #5eead4;
+}
+
+.tag-style-collab.tag-style-active {
+  color: #fff;
+  background: #0d9488;
+  border-color: #0d9488;
+}
+
+.tag-style-ayakaki {
+  color: #15803d;
+  background: #f0fdf4;
+  border-color: #86efac;
+}
+
+.tag-style-ayakaki.tag-style-active {
+  color: #fff;
+  background: #16a34a;
+  border-color: #16a34a;
+}
+
+.tag-style-default {
+  color: #374151;
+  background: #f9fafb;
+  border-color: #d1d5db;
+}
+
+.tag-style-default.tag-style-active {
+  color: #fff;
+  background: #4b5563;
+  border-color: #4b5563;
+}
+
+.tag-role {
+  color: #374151;
+  background: #fff;
+  border-color: #d1d5db;
+}
+
+.tag-role-active {
+  color: #fff;
+  background: #2563eb;
+  border-color: #2563eb;
+}
+
+.tag-role-vocal {
+  color: #1f2937;
+  background: #f3f4f6;
+  border-color: #d1d5db;
+}
+
+.tag-role-vocal.tag-role-active {
+  color: #fff;
+  background: #374151;
+  border-color: #374151;
+}
+
+.tag-role-dance {
+  color: #be123c;
+  background: #fff1f2;
+  border-color: #fecdd3;
+}
+
+.tag-role-dance.tag-role-active {
+  color: #fff;
+  background: #f43f5e;
+  border-color: #f43f5e;
+}
+
+.tag-role-piano {
+  color: #c2410c;
+  background: #fff7ed;
+  border-color: #fed7aa;
+}
+
+.tag-role-piano.tag-role-active {
+  color: #fff;
+  background: #fb923c;
+  border-color: #fb923c;
+}
+
+.tag-role-euphonium {
+  color: #b45309;
+  background: #fffbeb;
+  border-color: #fde68a;
+}
+
+.tag-role-euphonium.tag-role-active {
+  color: #fff;
+  background: #fbbf24;
+  border-color: #fbbf24;
+}
+
+.tag-role-movie {
+  color: #4d7c0f;
+  background: #f7fee7;
+  border-color: #d9f99d;
+}
+
+.tag-role-movie.tag-role-active {
+  color: #fff;
+  background: #84cc16;
+  border-color: #84cc16;
+}
+
+.tag-role-chorus {
+  color: #0369a1;
+  background: #f0f9ff;
+  border-color: #bae6fd;
+}
+
+.tag-role-chorus.tag-role-active {
+  color: #fff;
+  background: #0ea5e9;
+  border-color: #0ea5e9;
+}
+
+.tag-role-illustration {
+  color: #0e7490;
+  background: #ecfeff;
+  border-color: #a5f3fc;
+}
+
+.tag-role-illustration.tag-role-active {
+  color: #fff;
+  background: #06b6d4;
+  border-color: #06b6d4;
+}
+
+.tag-button:hover {
+  filter: brightness(0.98);
+}
+
+.tag-style:hover,
+.tag-time:hover,
+.tag-platform:hover,
+.tag-format:hover,
+.tag-format-3d:hover,
+.tag-role-filter:hover,
+.tag-collab-liver:hover,
+.tag-collab-unit:hover,
+.tag-role:hover {
+  filter: none;
+}
+
+.tag-style:hover { background: #bfdbfe; }
+.tag-time:hover { background: #bbf7d0; }
+.tag-platform:hover { background: #f3e8ff; }
+.tag-format:hover { background: #fce7f3; }
+.tag-format-3d:hover { background: #e0f2fe; }
+.tag-role-filter:hover { background: #fde68a; }
+.tag-collab-liver:hover { background: #f3f4f6; }
+.tag-collab-unit:hover { background: #dbeafe; }
+.tag-role:hover { background: #f3f4f6; }
+
+.tag-style-active:hover,
+.tag-time-active:hover,
+.tag-platform-active:hover,
+.tag-format-active:hover,
+.tag-format-3d-active:hover,
+.tag-role-filter-active:hover,
+.tag-collab-liver-active:hover,
+.tag-collab-unit-active:hover,
+.tag-role-active:hover {
+  filter: brightness(0.96);
+}
+
+.tag-sort.tag-sort-active:hover,
+.tag-style.tag-style-active:hover { background: #2563eb; }
+.tag-platform.tag-platform-active:hover { background: #9333ea; }
+.tag-time.tag-time-active:hover { background: #16a34a; }
+.tag-format.tag-format-active:hover { background: #db2777; }
+.tag-format-3d.tag-format-3d-active:hover { background: #0284c7; }
+.tag-role-filter.tag-role-filter-active:hover { background: #d97706; }
+.tag-desktop.tag-role-filter.tag-role-filter-active:hover { background: #ca8a04; }
+.tag-collab-liver.tag-collab-liver-active:hover { background: #4b5563; }
+.tag-sm.tag-collab-liver.tag-collab-liver-active:hover { background: #374151; }
+.tag-collab-unit.tag-collab-unit-active:hover { background: #2563eb; }
+.tag-role.tag-role-active:hover { background: #2563eb; }
+.tag-role-vocal.tag-role-active:hover { background: #374151; }
+.tag-role-dance.tag-role-active:hover { background: #f43f5e; }
+.tag-role-piano.tag-role-active:hover { background: #fb923c; }
+.tag-role-euphonium.tag-role-active:hover { background: #fbbf24; }
+.tag-role-movie.tag-role-active:hover { background: #84cc16; }
+.tag-role-chorus.tag-role-active:hover { background: #0ea5e9; }
+.tag-role-illustration.tag-role-active:hover { background: #06b6d4; }
+
 @media (max-height: 820px) {
   #desktopFilterPanel {
     max-height: 48vh;


### PR DESCRIPTION
## Summary
- Move tag color-related class definitions from JavaScript into style.css
- Replace long inline Tailwind class strings in tag rendering code with semantic CSS classes
- Keep existing tag behavior and filtering logic unchanged
- Prepare the tag UI for future color reorganization by tag part

## Changed files
- script.js
- mobile-filter-modal.js
- desktop-filter-panel.js
- style.css

## Checks
- Ran JavaScript syntax checks for script.js, mobile-filter-modal.js, and desktop-filter-panel.js
- Confirmed tag color class changes are primarily className/CSS-class refactors
- Confirmed filter logic, click handlers, search, random playback, and video playback logic were not intentionally changed
- Confirmed Time tags are included in the CSS class consolidation

## Not checked
- Browser visual confirmation is not completed because this work is being done online only, without local preview