### PR TITLE
Stabilize collab tag ordering

### DIFF
--- a/desktop-filter-panel.js
+++ b/desktop-filter-panel.js
@@ -87,11 +87,17 @@
   }
 
   function sortCollabValues(values) {
-    if (typeof window.sortCollabTagValues === "function") {
+    if (window.isCollabTagOrderReady && typeof window.sortCollabTagValues === "function") {
       return window.sortCollabTagValues(values);
     }
 
     return [...values].sort((a, b) => String(a).localeCompare(String(b), "ja"));
+  }
+
+  function sortRenderedCollabTags() {
+    if (window.isCollabTagOrderReady && typeof window.sortRenderedCollabTagContainers === "function") {
+      window.sortRenderedCollabTagContainers();
+    }
   }
 
   function renderSortButtons() {
@@ -217,6 +223,7 @@
   function renderCollabTags() {
     renderCollabGroup(collabLiverTags, getColumnValues("コラボライバー"), "collabLiver");
     renderCollabGroup(collabUnitTags, getColumnValues("コラボユニット"), "collabUnit");
+    sortRenderedCollabTags();
   }
 
   function renderDesktopPanel() {
@@ -255,6 +262,6 @@
   }
 
   window.addEventListener("collabTagOrderReady", () => {
-    if (!panel.classList.contains("hidden")) renderCollabTags();
+    renderCollabTags();
   });
 })();

--- a/index.html
+++ b/index.html
@@ -319,9 +319,9 @@ YouTube / TikTok の動画を掲載しています。
   <script src="./playing-scroll-position.js?v=2"></script>
   <script src="./script.js?v=23"></script>
   <script src="./waku-name-display.js?v=27"></script>
-  <script src="./mobile-filter-modal.js?v=24"></script>
-  <script src="./desktop-filter-panel.js?v=25"></script>
-  <script src="./ui-polish.js?v=27"></script>
+  <script src="./mobile-filter-modal.js?v=25"></script>
+  <script src="./desktop-filter-panel.js?v=26"></script>
+  <script src="./ui-polish.js?v=28"></script>
   <script src="./player-collapse.js?v=25"></script>
   <script src="./filter-scroll-position.js?v=26"></script>
   <script src="./youtube-stability.js?v=23"></script>

--- a/mobile-filter-modal.js
+++ b/mobile-filter-modal.js
@@ -155,11 +155,17 @@
   }
 
   function sortCollabValues(values) {
-    if (typeof window.sortCollabTagValues === "function") {
+    if (window.isCollabTagOrderReady && typeof window.sortCollabTagValues === "function") {
       return window.sortCollabTagValues(values);
     }
 
     return [...values].sort((a, b) => String(a).localeCompare(String(b), "ja"));
+  }
+
+  function sortRenderedCollabTags() {
+    if (window.isCollabTagOrderReady && typeof window.sortRenderedCollabTagContainers === "function") {
+      window.sortRenderedCollabTagContainers();
+    }
   }
 
   function getFormatValues() {
@@ -312,6 +318,7 @@
       collabUnitTagsContainer,
       getCsvTagValues("コラボユニット")
     );
+    sortRenderedCollabTags();
   }
 
   function renderMobileTagSections() {
@@ -467,6 +474,6 @@
   });
 
   window.addEventListener("collabTagOrderReady", () => {
-    if (!modal.classList.contains("hidden")) renderCollabTags();
+    renderCollabTags();
   });
 })();

--- a/ui-polish.js
+++ b/ui-polish.js
@@ -133,12 +133,17 @@
     window.isCollabTagOrderReady = isCollabTagOrderReady;
     window.getCollabTagSortInfo = getCollabSortInfoByLabel;
     window.sortCollabTagValues = sortCollabTagValues;
+    window.sortRenderedCollabTagContainers = sortAllCollabTagContainers;
     window.debugCollabTagOrder = debugCollabTagOrder;
   }
 
   function notifyCollabTagOrderReady() {
     exposeCollabTagOrder();
-    window.dispatchEvent(new CustomEvent("collabTagOrderReady"));
+    sortAllCollabTagContainers();
+    window.dispatchEvent(new CustomEvent("collabTagOrderReady", {
+      detail: { ready: isCollabTagOrderReady }
+    }));
+    requestAnimationFrame(sortAllCollabTagContainers);
   }
 
   function getCollabSortInfo(button) {
@@ -146,7 +151,7 @@
   }
 
   function sortCollabTagContainer(container) {
-    if (!container || isSortingCollabTags) return;
+    if (!container || isSortingCollabTags || !isCollabTagOrderReady) return;
 
     const buttons = [...container.children].filter(child => child.tagName === "BUTTON");
     if (buttons.length <= 1) return;
@@ -172,6 +177,8 @@
   }
 
   function sortAllCollabTagContainers() {
+    if (!isCollabTagOrderReady) return;
+
     COLLAB_TAG_CONTAINER_IDS.forEach(id => {
       sortCollabTagContainer(document.getElementById(id));
     });
@@ -210,9 +217,9 @@
 
         isCollabTagOrderReady = true;
         notifyCollabTagOrderReady();
-        sortAllCollabTagContainers();
       })
       .catch(() => {
+        exposeCollabTagOrder();
         // collab_tags が読めない場合は、元の表示順のまま使う。
       });
   }


### PR DESCRIPTION
## Summary
- Make collab tag sorting wait for `collab_tags` order data before using `window.sortCollabTagValues`
- Re-render and re-sort mobile and desktop Collab tag containers when `collabTagOrderReady` fires
- Expose `window.sortRenderedCollabTagContainers` so rendered fallback DOM can be corrected after order data is ready
- Update cache-buster versions for changed JS files in `index.html`

## Changed files
- `ui-polish.js`
- `mobile-filter-modal.js`
- `desktop-filter-panel.js`
- `index.html`

## Checks
- Ran `node --check ui-polish.js`
- Ran `node --check mobile-filter-modal.js`
- Ran `node --check desktop-filter-panel.js`
- Ran `git diff --check`
- Confirmed GitHub branch diff is limited to collab tag ordering stabilization and cache-buster updates
- Confirmed mobile Collab Liver / Unit tags display in `collab_tags` order in the local browser preview

## Not checked
- Full desktop visual verification in browser preview was not completed because the available in-app browser viewport rendered the mobile layout, and the separate desktop-width Playwright check could not launch a browser binary in this environment